### PR TITLE
chore(docs): split Read examples in README to separate sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,40 +386,53 @@ Reads the relationship tuples stored in the database. It does not evaluate nor e
 
 ```python
 # Find if a relationship tuple stating that a certain user is a viewer of certain document
-body = TupleKey(
+body = ReadRequest(
     user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
     relation="viewer",
     object="document:roadmap",
 )
+
+response = await api_instance.read(body)
+# response = ReadResponse({"tuples": [Tuple({"key": TupleKey({"user":"...","relation":"...","object":"..."}), "timestamp": datetime.fromisoformat("...") })]})
 ```
 
 ```python
 # Find all relationship tuples where a certain user has a relationship as any relation to a certain document
-body = TupleKey(
+body = ReadRequest(
     user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
     object="document:roadmap",
 )
+
+response = await api_instance.read(body)
+# response = ReadResponse({"tuples": [Tuple({"key": TupleKey({"user":"...","relation":"...","object":"..."}), "timestamp": datetime.fromisoformat("...") })]})
+
 ```
 
 ```python
 # Find all relationship tuples where a certain user is a viewer of any document
-body = TupleKey(
+body = ReadRequest(
     user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
     relation="viewer",
     object="document:",
 )
+
+response = await api_instance.read(body)
+# response = ReadResponse({"tuples": [Tuple({"key": TupleKey({"user":"...","relation":"...","object":"..."}), "timestamp": datetime.fromisoformat("...") })]})
 ```
 
 ```python
 # Find all relationship tuples where any user has a relationship as any relation with a particular document
-body = TupleKey(
+body = ReadRequest(
     object="document:roadmap",
 )
+
+response = await api_instance.read(body)
+# response = ReadResponse({"tuples": [Tuple({"key": TupleKey({"user":"...","relation":"...","object":"..."}), "timestamp": datetime.fromisoformat("...") })]})
 ```
 
 ```python
 # Read all stored relationship tuples
-body := ReadRequest()
+body = ReadRequest()
 
 response = await api_instance.read(body)
 # response = ReadResponse({"tuples": [Tuple({"key": TupleKey({"user":"...","relation":"...","object":"..."}), "timestamp": datetime.fromisoformat("...") })]})

--- a/README.md
+++ b/README.md
@@ -391,32 +391,39 @@ body = TupleKey(
     relation="viewer",
     object="document:roadmap",
 )
+```
 
+```python
 # Find all relationship tuples where a certain user has a relationship as any relation to a certain document
 body = TupleKey(
     user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
     object="document:roadmap",
 )
+```
 
+```python
 # Find all relationship tuples where a certain user is a viewer of any document
 body = TupleKey(
     user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
     relation="viewer",
     object="document:",
 )
+```
 
+```python
 # Find all relationship tuples where any user has a relationship as any relation with a particular document
 body = TupleKey(
     object="document:roadmap",
 )
+```
 
-// Read all stored relationship tuples
+```python
+# Read all stored relationship tuples
 body := ReadRequest()
 
 response = await api_instance.read(body)
 # response = ReadResponse({"tuples": [Tuple({"key": TupleKey({"user":"...","relation":"...","object":"..."}), "timestamp": datetime.fromisoformat("...") })]})
 ```
-
 
 ##### Write (Create and Delete) Relationship Tuples
 


### PR DESCRIPTION
<!-- Provide a brief summary of the changes -->

## Description
Edited README.md to create separate code blocks for Read Relationship Tuples example.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
[OpenFGA RFC](https://github.com/openfga/rfcs)
[Contributing to OpenFGA](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md)

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
