### PR TITLE
fix: correct typo in README read example

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,64 @@
+---
+name: Report an issue
+about: Create a bug report about an existing issue.
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+**Please do not report security vulnerabilities here**. See the [Responsible Disclosure Program](https://github.com/openfga/python-sdk/blob/main/.github/SECURITY.md).
+
+**Thank you in advance for helping us to improve this library!** Please read through the template below and answer all relevant questions. Your additional work here is greatly appreciated and will help us respond as quickly as possible.
+
+By submitting an issue to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/rfcs/blob/main/CODE-OF-CONDUCT.md).
+
+### Description
+
+> Provide a clear and concise description of the issue, including what you expected to happen.
+
+### Version of SDK
+
+> v0.2.0
+
+### Version of OpenFGA (if known)
+
+> v1.1.0
+
+### OpenFGA Flags/Custom Configuration Applicable
+
+>    environment:
+>      - OPENFGA_DATASTORE_ENGINE=postgres
+>      - OPENFGA_DATASTORE_URI=postgres://postgres:password@postgres:5432/postgres?sslmode=disable
+>      - OPENFGA_TRACE_ENABLED=true
+>      - OPENFGA_TRACE_SAMPLE_RATIO=1
+>      - OPENFGA_TRACE_OTLP_ENDPOINT=otel-collector:4317
+>      - OPENFGA_METRICS_ENABLE_RPC_HISTOGRAMS=true
+
+### Reproduction
+
+> Detail the steps taken to reproduce this error, what was expected, and whether this issue can be reproduced consistently or if it is intermittent.
+>
+> 1. Initialize OpenFgaClient with openfga_sdk.ClientConfiguration parameter api_host=127.0.0.1, credentials method client_credentials
+> 2. Invoke method read_authorization_models
+> 3. See exception thrown
+
+### Sample Code the Produces Issues
+
+>
+> ```
+> <code snippet>
+> ```
+
+### Backtrace (if applicable)
+
+> ```
+> <backtrace>
+> ```
+
+
+### Expected behavior
+> A clear and concise description of what you expected to happen.
+
+### Additional context
+> Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature request
+about: Suggest new functionality for this project.
+title: ''
+labels: 'feature'
+assignees: ''
+
+---
+
+**Please do not report security vulnerabilities here**. See the [Responsible Disclosure Program](https://github.com/openfga/python-sdk/blob/main/.github/SECURITY.md).
+
+**Thank you in advance for helping us to improve this library!** Please read through the template below and answer all relevant questions. Your additional work here is greatly appreciated and will help us respond as quickly as possible.
+
+By submitting an issue to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/rfcs/blob/main/CODE-OF-CONDUCT.md).
+
+### Describe the problem you'd like to have solved
+
+> A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+### Describe the ideal solution
+
+> A clear and concise description of what you want to happen.
+
+## Alternatives and current workarounds
+
+> A clear and concise description of any alternatives you've considered or any workarounds that are currently in place.
+
+### Additional context
+
+> Add any other context or screenshots about the feature request here.

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,7 @@
 name: Build, Test and Publish
 
 on:
+  merge_group:
   push:
   pull_request:
   workflow_dispatch:

--- a/.openapi-generator/FILES
+++ b/.openapi-generator/FILES
@@ -1,7 +1,7 @@
 .fossa.yml
 .github/CODEOWNERS
-.github/ISSUE_TEMPLATES/bug_report.md
-.github/ISSUE_TEMPLATES/feature_request.md
+.github/ISSUE_TEMPLATE/bug_report.md
+.github/ISSUE_TEMPLATE/feature_request.md
 .github/workflows/main.yaml
 .github/workflows/semgrep.yaml
 .gitignore

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ Reads the relationship tuples stored in the database. It does not evaluate nor e
 
 ```python
 # Find if a relationship tuple stating that a certain user is a viewer of certain document
-body = ReadRequest(
+body = TupleKey(
     user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
     relation="viewer",
     object="document:roadmap",
@@ -398,7 +398,7 @@ response = await fga_client.read(body)
 
 ```python
 # Find all relationship tuples where a certain user has a relationship as any relation to a certain document
-body = ReadRequest(
+body = TupleKey(
     user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
     object="document:roadmap",
 )
@@ -410,7 +410,7 @@ response = await fga_client.read(body)
 
 ```python
 # Find all relationship tuples where a certain user is a viewer of any document
-body = ReadRequest(
+body = TupleKey(
     user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
     relation="viewer",
     object="document:",
@@ -422,7 +422,7 @@ response = await fga_client.read(body)
 
 ```python
 # Find all relationship tuples where any user has a relationship as any relation with a particular document
-body = ReadRequest(
+body = TupleKey(
     object="document:roadmap",
 )
 
@@ -432,9 +432,9 @@ response = await fga_client.read(body)
 
 ```python
 # Read all stored relationship tuples
-body = ReadRequest()
+body = TupleKey()
 
-response = await fga_client.read(body)
+response = await api_instance.read(body)
 # response = ReadResponse({"tuples": [Tuple({"key": TupleKey({"user":"...","relation":"...","object":"..."}), "timestamp": datetime.fromisoformat("...") })]})
 ```
 

--- a/openfga_sdk/api_client.py
+++ b/openfga_sdk/api_client.py
@@ -34,6 +34,9 @@ from openfga_sdk import rest
 from openfga_sdk.exceptions import ApiValueError, ApiException, FgaValidationException, RateLimitExceededError
 
 
+DEFAULT_USER_AGENT = 'openfga-sdk python/0.2.0'
+
+
 def random_time(loop_count, min_wait_in_ms):
     """
     Helper function to return the time (in s) to wait before retry
@@ -91,8 +94,7 @@ class ApiClient(object):
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'openfga-sdk {sdkId}/{packageVersion}'.replace(
-            '{sdkId}', 'python').replace('{packageVersion}', '0.2.0')
+        self.user_agent = DEFAULT_USER_AGENT
         self.client_side_validation = configuration.client_side_validation
 
     async def __aenter__(self):


### PR DESCRIPTION

## Description
1. Fix typo in README's read example 
2. Bring in changes for header generator

## References
Related to https://github.com/openfga/sdk-generator/pull/141

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
