### PR TITLE
fix(docs): incorrect path for sync client README

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ without requiring async/await.
 
 ```python
 import openfga_sdk
-from openfga_sdk.sync.client import OpenFgaClient
+from openfga_sdk.sync import OpenFgaClient
 
 
 def main():


### PR DESCRIPTION
Fixing incorrect path for synchronous client in README.md

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
