### PR TITLE
feat: allow passing in custom ssl certs to client config

### DIFF
--- a/openfga_sdk/client/configuration.py
+++ b/openfga_sdk/client/configuration.py
@@ -22,14 +22,16 @@ class ClientConfiguration(Configuration):
     """
 
     def __init__(
-            self,
-            api_scheme="https",
-            api_host=None,
-            store_id=None,
-            credentials=None,
-            retry_params=None,
-            authorization_model_id=None, ):
-        super().__init__(api_scheme, api_host, store_id, credentials, retry_params)
+        self,
+        api_scheme="https",
+        api_host=None,
+        store_id=None,
+        credentials=None,
+        retry_params=None,
+        authorization_model_id=None,
+        ssl_ca_cert=None,
+    ):
+        super().__init__(api_scheme, api_host, store_id, credentials, retry_params, ssl_ca_cert=ssl_ca_cert)
         self._authorization_model_id = authorization_model_id
 
     def is_valid(self):


### PR DESCRIPTION
As reported in #49, the user needs to be able to pass the path to their own certificate in order to support requests using an old version of the module `requests==2.2.0`.

## Description

In order to be able to successfully communicate with fga, the user needs to pass their own custom ssl_ca_cert since they are on an older version of `requests` and `urllib3`. The error they are getting is the following:
 
```
MaxRetryError: HTTPSConnectionPool(host='api.us1.fga.dev', port=443): Max retries exceeded with url: /stores/01HHFHCC0PBS22DEGPJGFDE2W3/write (Caused by SSLError(SSLError("bad handshake: Error([('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')])")))
```

This pull request extends the `ClientConfiguration` class to also receive the `ssl_cert_ca` param to pass down to the client's configuration.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
- Supersedes #49 (the original PR, with the approval of the submitter)

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
