### PR TITLE
feat: support api_url configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,7 @@ from openfga_sdk import ClientConfiguration, OpenFgaClient
 
 async def main():
     configuration = ClientConfiguration(
-        api_scheme=FGA_API_SCHEME,  # optional, defaults to "https"
-        api_host=FGA_API_HOST,  # required, define without the scheme (e.g. api.fga.example instead of https://api.fga.example)
+        api_url=FGA_API_URL,  # required
         store_id=FGA_STORE_ID,  # optional, not needed when calling `CreateStore` or `ListStores`
         authorization_model_id=FGA_AUTHORIZATION_MODEL_ID,  # Optional, can be overridden per request
     )
@@ -150,8 +149,7 @@ from openfga_sdk.credentials import CredentialConfiguration, Credentials
 
 async def main():
     configuration = ClientConfiguration(
-        api_scheme=FGA_API_SCHEME,  # optional, defaults to "https"
-        api_host=FGA_API_HOST,  # required, define without the scheme (e.g. api.fga.example instead of https://api.fga.example)
+        api_url=FGA_API_URL,  # required
         store_id=FGA_STORE_ID,  # optional, not needed when calling `CreateStore` or `ListStores`
         authorization_model_id=FGA_AUTHORIZATION_MODEL_ID,  # Optional, can be overridden per request
         credentials=Credentials(
@@ -177,8 +175,7 @@ from openfga_sdk.credentials import Credentials, CredentialConfiguration
 
 async def main():
     configuration = ClientConfiguration(
-        api_scheme=FGA_API_SCHEME,  # optional, defaults to "https"
-        api_host=FGA_API_HOST,  # required, define without the scheme (e.g. api.fga.example instead of https://api.fga.example)
+        api_url=FGA_API_URL,  # required
         store_id=FGA_STORE_ID,  # optional, not needed when calling `CreateStore` or `ListStores`
         authorization_model_id=FGA_AUTHORIZATION_MODEL_ID,  # Optional, can be overridden per request
         credentials=Credentials(
@@ -196,7 +193,6 @@ async def main():
         api_response = await fga_client.read_authorization_models()
         await fga_client.close()
         return api_response
-
 ```
 
 #### Synchronous Client
@@ -206,14 +202,12 @@ from `openfga_sdk.sync` that supports all the credential types and calls,
 without requiring async/await.
 
 ```python
-from openfga_sdk import ClientConfiguration
-from openfga_sdk.sync import OpenFgaClient
+from openfga_sdk.sync import ClientConfiguration, OpenFgaClient
 
 
 def main():
     configuration = ClientConfiguration(
-        api_scheme=FGA_API_SCHEME,  # optional, defaults to "https"
-        api_host=FGA_API_HOST,  # required, define without the scheme (e.g. api.fga.example instead of https://api.fga.example)
+        api_url=FGA_API_URL,  # required
         store_id=FGA_STORE_ID,  # optional, not needed when calling `CreateStore` or `ListStores`
         authorization_model_id=FGA_AUTHORIZATION_MODEL_ID,  # optional, can be overridden per request
     )
@@ -221,7 +215,6 @@ def main():
     with OpenFgaClient(configuration) as fga_client:
         api_response = fga_client.read_authorization_models()
         return api_response
-
 ```
 
 
@@ -960,7 +953,6 @@ body = [ClientAssertion(
 )]
 
 response = await fga_client.write_assertions(body, options)
-
 ```
 
 

--- a/example/example1/example1.py
+++ b/example/example1/example1.py
@@ -22,15 +22,14 @@ async def main():
             )
         )
 
-    if os.getenv('FGA_API_HOST') is not None:
+    if os.getenv('FGA_API_URL') is not None:
         configuration = ClientConfiguration(
-            api_host=os.getenv('FGA_API_HOST'),
+            api_url=os.getenv('FGA_API_URL'),
             credentials=credentials
         )
     else:
         configuration = ClientConfiguration(
-            api_scheme='http',
-            api_host='localhost:8080',
+            api_url='http://localhost:8080',
             credentials=credentials
         )
 

--- a/openfga_sdk/api_client.py
+++ b/openfga_sdk/api_client.py
@@ -191,7 +191,10 @@ class ApiClient(object):
 
         # request url
         if _host is None:
-            url = self.configuration.api_scheme + '://' + self.configuration.api_host + resource_path
+            if self.configuration.api_url is not None:
+                url = self.configuration.api_url + resource_path
+            else:
+                url = self.configuration.api_scheme + '://' + self.configuration.api_host + resource_path
         else:
             # use server/host defined in path or operation instead
             url = self.configuration.api_scheme + '://' + _host + resource_path

--- a/openfga_sdk/client/configuration.py
+++ b/openfga_sdk/client/configuration.py
@@ -25,15 +25,15 @@ class ClientConfiguration(Configuration):
         self,
         api_scheme="https",
         api_host=None,
-        api_url=None,
         store_id=None,
         credentials=None,
         retry_params=None,
         authorization_model_id=None,
         ssl_ca_cert=None,
+        api_url=None,  # TODO: restructure when removing api_scheme/api_host
     ):
-        super().__init__(api_scheme, api_host, api_url, store_id,
-                         credentials, retry_params, ssl_ca_cert=ssl_ca_cert)
+        super().__init__(api_scheme, api_host, store_id, credentials,
+                         retry_params, ssl_ca_cert=ssl_ca_cert, api_url=api_url)
         self._authorization_model_id = authorization_model_id
 
     def is_valid(self):

--- a/openfga_sdk/client/configuration.py
+++ b/openfga_sdk/client/configuration.py
@@ -25,13 +25,15 @@ class ClientConfiguration(Configuration):
         self,
         api_scheme="https",
         api_host=None,
+        api_url=None,
         store_id=None,
         credentials=None,
         retry_params=None,
         authorization_model_id=None,
         ssl_ca_cert=None,
     ):
-        super().__init__(api_scheme, api_host, store_id, credentials, retry_params, ssl_ca_cert=ssl_ca_cert)
+        super().__init__(api_scheme, api_host, api_url, store_id,
+                         credentials, retry_params, ssl_ca_cert=ssl_ca_cert)
         self._authorization_model_id = authorization_model_id
 
     def is_valid(self):

--- a/openfga_sdk/configuration.py
+++ b/openfga_sdk/configuration.py
@@ -89,7 +89,6 @@ class Configuration(object):
     :param api_host: Base url
         .. deprecated:: 0.4.1
             Use `api_url` instead.
-    :param api_url: str - the URL of the FGA server
     :param store_id: ID of store for API
     :param credentials: Configuration for obtaining authentication credential
     :param retry_params: Retry parameters upon HTTP too many request
@@ -137,11 +136,12 @@ class Configuration(object):
       The validation of enums is performed for variables with defined enum values before.
     :param ssl_ca_cert: str - the path to a file of concatenated CA certificates
       in PEM format
+    :param api_url: str - the URL of the FGA server
     """
 
     _default = None
 
-    def __init__(self, api_scheme="https", api_host=None, api_url=None,
+    def __init__(self, api_scheme="https", api_host=None,
                  store_id=None,
                  credentials=None,
                  retry_params=None,
@@ -152,6 +152,7 @@ class Configuration(object):
                  server_index=None, server_variables=None,
                  server_operation_index=None, server_operation_variables=None,
                  ssl_ca_cert=None,
+                 api_url=None,  # TODO: restructure when removing api_scheme/api_host
                  ):
         """Constructor
         """

--- a/openfga_sdk/sync/api_client.py
+++ b/openfga_sdk/sync/api_client.py
@@ -190,7 +190,10 @@ class ApiClient(object):
 
         # request url
         if _host is None:
-            url = self.configuration.api_scheme + '://' + self.configuration.api_host + resource_path
+            if self.configuration.api_url is not None:
+                url = self.configuration.api_url + resource_path
+            else:
+                url = self.configuration.api_scheme + '://' + self.configuration.api_host + resource_path
         else:
             # use server/host defined in path or operation instead
             url = self.configuration.api_scheme + '://' + _host + resource_path

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -95,8 +95,7 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
 
     def setUp(self):
         self.configuration = ClientConfiguration(
-            api_scheme='http',
-            api_host="api.fga.example",
+            api_url='http://api.fga.example',
         )
 
     def tearDown(self):

--- a/test/test_client_sync.py
+++ b/test/test_client_sync.py
@@ -95,8 +95,7 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
 
     def setUp(self):
         self.configuration = ClientConfiguration(
-            api_scheme='http',
-            api_host="api.fga.example",
+            api_url='http://api.fga.example',
         )
 
     def tearDown(self):

--- a/test/test_open_fga_api.py
+++ b/test/test_open_fga_api.py
@@ -100,8 +100,7 @@ class TestOpenFgaApi(IsolatedAsyncioTestCase):
 
     def setUp(self):
         self.configuration = openfga_sdk.Configuration(
-            api_scheme='http',
-            api_host="api.fga.example",
+            api_url='http://api.fga.example',
         )
 
     def tearDown(self):
@@ -922,6 +921,28 @@ class TestOpenFgaApi(IsolatedAsyncioTestCase):
             store_id="abcd"
         )
         self.assertRaises(FgaValidationException, configuration.is_valid)
+
+    def test_url(self):
+        """
+        Ensure that api_url is set and validated
+        """
+        configuration = openfga_sdk.Configuration(
+            api_url='http://localhost:8080'
+        )
+        self.assertEqual(configuration.api_url, 'http://localhost:8080')
+        configuration.is_valid()
+
+    def test_url_with_scheme_and_host(self):
+        """
+        Ensure that api_url takes precedence over api_host and scheme
+        """
+        configuration = openfga_sdk.Configuration(
+            api_url='http://localhost:8080',
+            api_host='localhost:8080',
+            api_scheme='foo'
+        )
+        self.assertEqual(configuration.api_url, 'http://localhost:8080')
+        configuration.is_valid()  # Should not throw and complain about scheme being invalid
 
     async def test_bad_configuration_read_authorization_model(self):
         """

--- a/test/test_open_fga_api_sync.py
+++ b/test/test_open_fga_api_sync.py
@@ -101,8 +101,7 @@ class TestOpenFgaApiSync(IsolatedAsyncioTestCase):
 
     def setUp(self):
         self.configuration = Configuration(
-            api_scheme='http',
-            api_host="api.fga.example",
+            api_url='http://api.fga.example',
         )
 
     def tearDown(self):
@@ -923,6 +922,28 @@ class TestOpenFgaApiSync(IsolatedAsyncioTestCase):
             store_id="abcd"
         )
         self.assertRaises(FgaValidationException, configuration.is_valid)
+
+    def test_url(self):
+        """
+        Ensure that api_url is set and validated
+        """
+        configuration = Configuration(
+            api_url='http://localhost:8080'
+        )
+        self.assertEqual(configuration.api_url, 'http://localhost:8080')
+        configuration.is_valid()
+
+    def test_url_with_scheme_and_host(self):
+        """
+        Ensure that api_url takes precedence over api_host and scheme
+        """
+        configuration = Configuration(
+            api_url='http://localhost:8080',
+            api_host='localhost:8080',
+            api_scheme='foo'
+        )
+        self.assertEqual(configuration.api_url, 'http://localhost:8080')
+        configuration.is_valid()  # Should not throw and complain about scheme being invalid
 
     async def test_bad_configuration_read_authorization_model(self):
         """


### PR DESCRIPTION
## Description

Adds support for an `api_url` configuration option and deprecated the existing `apiHost` and `apiScheme` options


## References

Part of openfga/sdk-generator/issues/298
Generated from: https://github.com/openfga/sdk-generator/pull/302

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
