### PR TITLE
fix: use correct content type for token request

### DIFF
--- a/openfga_sdk/oauth2.py
+++ b/openfga_sdk/oauth2.py
@@ -47,15 +47,15 @@ class OAuth2Client:
         """
         configuration = self._credentials.configuration
         token_url = 'https://{}/oauth/token'.format(configuration.api_issuer)
-        body = {
+        post_params = {
             'client_id': configuration.client_id,
             'client_secret': configuration.client_secret,
             'audience': configuration.api_audience,
             'grant_type': "client_credentials",
         }
         headers = urllib3.response.HTTPHeaderDict(
-            {'Accept': 'application/json', 'Content-Type': 'application/json', 'User-Agent': 'openfga-sdk (python) 0.4.0'})
-        raw_response = await client.POST(token_url, headers=headers, body=body)
+            {'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': 'openfga-sdk (python) 0.4.0'})
+        raw_response = await client.POST(token_url, headers=headers, post_params=post_params)
         if 200 <= raw_response.status <= 299:
             try:
                 api_response = json.loads(raw_response.data)

--- a/openfga_sdk/sync/oauth2.py
+++ b/openfga_sdk/sync/oauth2.py
@@ -47,15 +47,15 @@ class OAuth2Client:
         """
         configuration = self._credentials.configuration
         token_url = 'https://{}/oauth/token'.format(configuration.api_issuer)
-        body = {
+        post_params = {
             'client_id': configuration.client_id,
             'client_secret': configuration.client_secret,
             'audience': configuration.api_audience,
             'grant_type': "client_credentials",
         }
         headers = urllib3.response.HTTPHeaderDict(
-            {'Accept': 'application/json', 'Content-Type': 'application/json', 'User-Agent': 'openfga-sdk (python) 0.4.0'})
-        raw_response = client.POST(token_url, headers=headers, body=body)
+            {'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': 'openfga-sdk (python) 0.4.0'})
+        raw_response = client.POST(token_url, headers=headers, post_params=post_params)
         if 200 <= raw_response.status <= 299:
             try:
                 api_response = json.loads(raw_response.data)

--- a/test/test_oauth2.py
+++ b/test/test_oauth2.py
@@ -82,14 +82,14 @@ class TestOAuth2Client(IsolatedAsyncioTestCase):
         self.assertGreaterEqual(client._access_expiry_time,
                                 current_time + timedelta(seconds=int(120)))
         expected_header = urllib3.response.HTTPHeaderDict(
-            {'Accept': 'application/json', 'Content-Type': 'application/json', 'User-Agent': 'openfga-sdk (python) 0.4.0'})
+            {'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': 'openfga-sdk (python) 0.4.0'})
         mock_request.assert_called_once_with(
             'POST',
             'https://www.testme.com/oauth/token',
             headers=expected_header,
-            query_params=None, post_params=None, _preload_content=True, _request_timeout=None,
-            body={"client_id": "myclientid", "client_secret": "mysecret",
-                  "audience": "myaudience", "grant_type": "client_credentials"}
+            query_params=None, body=None, _preload_content=True, _request_timeout=None,
+            post_params={"client_id": "myclientid", "client_secret": "mysecret",
+                         "audience": "myaudience", "grant_type": "client_credentials"}
         )
         await rest_client.close()
 

--- a/test/test_oauth2_sync.py
+++ b/test/test_oauth2_sync.py
@@ -83,14 +83,14 @@ class TestOAuth2Client(IsolatedAsyncioTestCase):
         self.assertGreaterEqual(client._access_expiry_time,
                                 current_time + timedelta(seconds=int(120)))
         expected_header = urllib3.response.HTTPHeaderDict(
-            {'Accept': 'application/json', 'Content-Type': 'application/json', 'User-Agent': 'openfga-sdk (python) 0.4.0'})
+            {'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': 'openfga-sdk (python) 0.4.0'})
         mock_request.assert_called_once_with(
             'POST',
             'https://www.testme.com/oauth/token',
             headers=expected_header,
-            query_params=None, post_params=None, _preload_content=True, _request_timeout=None,
-            body={"client_id": "myclientid", "client_secret": "mysecret",
-                  "audience": "myaudience", "grant_type": "client_credentials"}
+            query_params=None, body=None, _preload_content=True, _request_timeout=None,
+            post_params={"client_id": "myclientid", "client_secret": "mysecret",
+                         "audience": "myaudience", "grant_type": "client_credentials"}
         )
         rest_client.close()
 


### PR DESCRIPTION
## Description

Moves the client to use `application/x-www-form-urlencoded` for the content type when making token requests per the spec.

In order to do this we set the header on the request and provide `post_params` instead of `body` on the request.

## References

Part of https://github.com/openfga/sdk-generator/issues/284
Generated from https://github.com/openfga/sdk-generator/issues/308

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
