### PR TITLE
feat: support auto-retries of 5xx HTTP responses

### DIFF
--- a/openfga_sdk/api_client.py
+++ b/openfga_sdk/api_client.py
@@ -30,6 +30,7 @@ from openfga_sdk.exceptions import (
     ApiValueError,
     FgaValidationException,
     RateLimitExceededError,
+    ServiceException,
 )
 
 DEFAULT_USER_AGENT = "openfga-sdk python/0.4.1"
@@ -257,8 +258,8 @@ class ApiClient:
                     _preload_content=_preload_content,
                     _request_timeout=_request_timeout,
                 )
-            except RateLimitExceededError as e:
-                if x < max_retry:
+            except (RateLimitExceededError, ServiceException) as e:
+                if x < max_retry and e.status != 501:
                     await asyncio.sleep(random_time(x, min_wait_in_ms))
 
                     continue

--- a/openfga_sdk/sync/api_client.py
+++ b/openfga_sdk/sync/api_client.py
@@ -29,6 +29,7 @@ from openfga_sdk.exceptions import (
     ApiValueError,
     FgaValidationException,
     RateLimitExceededError,
+    ServiceException,
 )
 from openfga_sdk.sync import oauth2, rest
 
@@ -256,8 +257,8 @@ class ApiClient:
                     _preload_content=_preload_content,
                     _request_timeout=_request_timeout,
                 )
-            except RateLimitExceededError as e:
-                if x < max_retry:
+            except (RateLimitExceededError, ServiceException) as e:
+                if x < max_retry and e.status != 501:
                     time.sleep(random_time(x, min_wait_in_ms))
                     continue
                 e.body = e.body.decode("utf-8")

--- a/test/test_open_fga_api.py
+++ b/test/test_open_fga_api.py
@@ -1250,8 +1250,10 @@ class TestOpenFgaApi(IsolatedAsyncioTestCase):
             http_resp=http_mock_response(response_body, 500)
         )
 
+        retry = openfga_sdk.configuration.RetryParams(0, 10)
         configuration = self.configuration
         configuration.store_id = store_id
+        configuration.retry_params = retry
         async with openfga_sdk.ApiClient(configuration) as api_client:
             api_instance = open_fga_api.OpenFgaApi(api_client)
             body = CheckRequest(
@@ -1276,6 +1278,89 @@ class TestOpenFgaApi(IsolatedAsyncioTestCase):
                 api_exception.exception.parsed_exception.message,
                 "Internal Server Error",
             )
+            mock_request.assert_called()
+            self.assertEqual(mock_request.call_count, 1)
+
+    @patch.object(rest.RESTClientObject, "request")
+    async def test_500_error_retry(self, mock_request):
+        """
+        Test to ensure 5xxx retries  are handled properly
+        """
+        response_body = """
+{
+  "code": "internal_error",
+  "message": "Internal Server Error"
+}
+        """
+        mock_request.side_effect = [
+            ServiceException(http_resp=http_mock_response(response_body, 500)),
+            ServiceException(http_resp=http_mock_response(response_body, 502)),
+            ServiceException(http_resp=http_mock_response(response_body, 503)),
+            ServiceException(http_resp=http_mock_response(response_body, 504)),
+            mock_response(response_body, 200),
+        ]
+
+        retry = openfga_sdk.configuration.RetryParams(5, 10)
+        configuration = self.configuration
+        configuration.store_id = store_id
+        configuration.retry_params = retry
+
+        async with openfga_sdk.ApiClient(configuration) as api_client:
+            api_instance = open_fga_api.OpenFgaApi(api_client)
+            body = CheckRequest(
+                tuple_key=TupleKey(
+                    object="document:2021-budget",
+                    relation="reader",
+                    user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+                ),
+            )
+
+            api_response = await api_instance.check(
+                body=body,
+            )
+
+            self.assertIsInstance(api_response, CheckResponse)
+            mock_request.assert_called()
+            self.assertEqual(mock_request.call_count, 5)
+
+    @patch.object(rest.RESTClientObject, "request")
+    async def test_501_error_retry(self, mock_request):
+        """
+        Test to ensure 501 responses are not auto-retried
+        """
+        response_body = """
+{
+  "code": "not_implemented",
+  "message": "Not Implemented"
+}
+        """
+        mock_request.side_effect = [
+            ServiceException(http_resp=http_mock_response(response_body, 501)),
+            ServiceException(http_resp=http_mock_response(response_body, 501)),
+            ServiceException(http_resp=http_mock_response(response_body, 501)),
+            mock_response(response_body, 200),
+        ]
+
+        retry = openfga_sdk.configuration.RetryParams(5, 10)
+        configuration = self.configuration
+        configuration.store_id = store_id
+        configuration.retry_params = retry
+
+        async with openfga_sdk.ApiClient(configuration) as api_client:
+            api_instance = open_fga_api.OpenFgaApi(api_client)
+            body = CheckRequest(
+                tuple_key=TupleKey(
+                    object="document:2021-budget",
+                    relation="reader",
+                    user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+                ),
+            )
+            with self.assertRaises(ServiceException) as api_exception:
+                await api_instance.check(
+                    body=body,
+                )
+            mock_request.assert_called()
+            self.assertEqual(mock_request.call_count, 1)
 
     @patch.object(rest.RESTClientObject, "request")
     async def test_check_api_token(self, mock_request):


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This PR extends the SDK's auto-retry function of certain failed HTTP requests, based on the response's HTTP status code, to include 5xx series errors (not including 501s.)

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

Closes #73 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
