### PR TITLE
fix: remove `ReadAuthorizationModel` calls from `BatchCheck` and writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ credentials.json
 
 VERSION.txt
 git_push.sh
+setup.local.cfg

--- a/openfga_sdk/sync/client/client.py
+++ b/openfga_sdk/sync/client/client.py
@@ -32,7 +32,11 @@ from openfga_sdk.client.models.write_single_response import (
     construct_write_single_response,
 )
 from openfga_sdk.client.models.write_transaction_opts import WriteTransactionOpts
-from openfga_sdk.exceptions import FgaValidationException
+from openfga_sdk.exceptions import (
+    AuthenticationError,
+    FgaValidationException,
+    UnauthorizedException,
+)
 from openfga_sdk.models.assertion import Assertion
 from openfga_sdk.models.check_request import CheckRequest
 from openfga_sdk.models.contextual_tuple_keys import ContextualTupleKeys
@@ -177,16 +181,6 @@ class OpenFgaClient:
         Return the authorization model id
         """
         return self._client_configuration.authorization_model_id
-
-    def _check_valid_api_connection(self, options: dict[str, int | str]):
-        """
-        Checks that a connection with the given configuration can be established
-        """
-        authorization_model_id = self._get_authorization_model_id(options)
-        if authorization_model_id is not None and authorization_model_id != "":
-            self.read_authorization_model(options)
-        else:
-            self.read_latest_authorization_model(options)
 
     #################
     # Stores
@@ -410,6 +404,8 @@ class OpenFgaClient:
                 ClientWriteRequest(writes=write_batch, deletes=delete_batch), options
             )
             return [construct_write_single_response(i, True, None) for i in batch]
+        except (AuthenticationError, UnauthorizedException) as err:
+            raise err
         except Exception as err:
             return [construct_write_single_response(i, False, err) for i in batch]
 
@@ -493,8 +489,6 @@ class OpenFgaClient:
         options = set_heading_if_not_set(
             options, CLIENT_BULK_REQUEST_ID_HEADER, str(uuid.uuid4())
         )
-        # TODO: this should be run in parallel
-        self._check_valid_api_connection(options)
 
         # otherwise, it is not a transaction and it is a batch write requests
         writes_response = None
@@ -584,6 +578,8 @@ class OpenFgaClient:
                 response=api_response,
                 error=None,
             )
+        except (AuthenticationError, UnauthorizedException) as err:
+            raise err
         except Exception as err:
             return BatchCheckResponse(
                 allowed=False, request=body, response=None, error=err
@@ -606,9 +602,6 @@ class OpenFgaClient:
         options = set_heading_if_not_set(
             options, CLIENT_BULK_REQUEST_ID_HEADER, str(uuid.uuid4())
         )
-
-        # TODO: this should be run in parallel
-        self._check_valid_api_connection(options)
 
         max_parallel_requests = 10
         if options is not None and "max_parallel_requests" in options:

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -974,7 +974,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             mock_response("{}", 200),
             mock_response("{}", 200),
             mock_response("{}", 200),
-            mock_response("{}", 200),
         ]
         configuration = self.configuration
         configuration.store_id = store_id
@@ -1043,15 +1042,7 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                     ),
                 ],
             )
-            self.assertEqual(mock_request.call_count, 4)
-            mock_request.assert_any_call(
-                "GET",
-                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01G5JAVJ41T49E9TT3SKVS7X1J",
-                headers=ANY,
-                query_params=[],
-                _preload_content=ANY,
-                _request_timeout=None,
-            )
+            self.assertEqual(mock_request.call_count, 3)
             mock_request.assert_any_call(
                 "POST",
                 "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/write",
@@ -1126,7 +1117,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             mock_response("{}", 200),
             mock_response("{}", 200),
             mock_response("{}", 200),
-            mock_response("{}", 200),
         ]
         configuration = self.configuration
         configuration.store_id = store_id
@@ -1195,15 +1185,7 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                     ),
                 ],
             )
-            self.assertEqual(mock_request.call_count, 4)
-            mock_request.assert_any_call(
-                "GET",
-                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01G5JAVJ41T49E9TT3SKVS7X1J",
-                headers=ANY,
-                query_params=[],
-                _preload_content=ANY,
-                _request_timeout=None,
-            )
+            self.assertEqual(mock_request.call_count, 3)
             mock_request.assert_any_call(
                 "POST",
                 "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/write",
@@ -1277,7 +1259,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
         mock_request.side_effect = [
             mock_response("{}", 200),
             mock_response("{}", 200),
-            mock_response("{}", 200),
         ]
         configuration = self.configuration
         configuration.store_id = store_id
@@ -1346,15 +1327,7 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                     ),
                 ],
             )
-            self.assertEqual(mock_request.call_count, 3)
-            mock_request.assert_any_call(
-                "GET",
-                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01G5JAVJ41T49E9TT3SKVS7X1J",
-                headers=ANY,
-                query_params=[],
-                _preload_content=ANY,
-                _request_timeout=None,
-            )
+            self.assertEqual(mock_request.call_count, 2)
             mock_request.assert_any_call(
                 "POST",
                 "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/write",
@@ -1417,7 +1390,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
         """
 
         mock_request.side_effect = [
-            mock_response("{}", 200),
             mock_response("{}", 200),
             ValidationException(http_resp=http_mock_response(response_body, 400)),
             mock_response("{}", 200),
@@ -1496,15 +1468,7 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                     error=None,
                 ),
             )
-            self.assertEqual(mock_request.call_count, 4)
-            mock_request.assert_any_call(
-                "GET",
-                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01G5JAVJ41T49E9TT3SKVS7X1J",
-                headers=ANY,
-                query_params=[],
-                _preload_content=ANY,
-                _request_timeout=None,
-            )
+            self.assertEqual(mock_request.call_count, 3)
             mock_request.assert_any_call(
                 "POST",
                 "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/write",
@@ -1577,7 +1541,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
         """
         mock_request.side_effect = [
             mock_response("{}", 200),
-            mock_response("{}", 200),
         ]
         configuration = self.configuration
         configuration.store_id = store_id
@@ -1602,14 +1565,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                     "authorization_model_id": "01G5JAVJ41T49E9TT3SKVS7X1J",
                     "transaction": transaction,
                 },
-            )
-            mock_request.assert_any_call(
-                "GET",
-                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01G5JAVJ41T49E9TT3SKVS7X1J",
-                headers=ANY,
-                query_params=[],
-                _preload_content=ANY,
-                _request_timeout=None,
             )
             mock_request.assert_any_call(
                 "POST",
@@ -1771,7 +1726,7 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
         configuration = self.configuration
         configuration.store_id = store_id
         async with OpenFgaClient(configuration) as api_client:
-            with self.assertRaises(UnauthorizedException) as api_exception:
+            with self.assertRaises(UnauthorizedException):
                 body = ClientWriteRequest(
                     writes=[
                         ClientTuple(
@@ -1792,17 +1747,29 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                     },
                 )
 
-            self.assertIsInstance(api_exception.exception, UnauthorizedException)
             mock_request.assert_called()
             self.assertEqual(mock_request.call_count, 1)
 
             mock_request.assert_called_once_with(
-                "GET",
-                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01G5JAVJ41T49E9TT3SKVS7X1J",
+                "POST",
+                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/write",
                 headers=ANY,
                 query_params=[],
+                post_params=[],
+                body={
+                    "writes": {
+                        "tuple_keys": [
+                            {
+                                "user": "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+                                "relation": "reader",
+                                "object": "document:2021-budget",
+                            }
+                        ]
+                    },
+                    "authorization_model_id": "01G5JAVJ41T49E9TT3SKVS7X1J",
+                },
                 _preload_content=ANY,
-                _request_timeout=None,
+                _request_timeout=ANY,
             )
             await api_client.close()
 
@@ -1918,7 +1885,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
         # First, mock the response
         response_body = '{"allowed": true, "resolution": "1234"}'
         mock_request.side_effect = [
-            mock_response("{}", 200),
             mock_response(response_body, 200),
         ]
         body = ClientCheckRequest(
@@ -1939,14 +1905,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             self.assertTrue(api_response[0].allowed)
             self.assertEqual(api_response[0].request, body)
             # Make sure the API was called with the right data
-            mock_request.assert_any_call(
-                "GET",
-                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01GXSA8YR785C4FYS3C0RTG7B1",
-                headers=ANY,
-                query_params=[],
-                _preload_content=ANY,
-                _request_timeout=None,
-            )
             mock_request.assert_any_call(
                 "POST",
                 "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/check",
@@ -1975,7 +1933,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
 
         # First, mock the response
         mock_request.side_effect = [
-            mock_response("{}", 200),
             mock_response('{"allowed": true, "resolution": "1234"}', 200),
             mock_response('{"allowed": false, "resolution": "1234"}', 200),
             mock_response('{"allowed": true, "resolution": "1234"}', 200),
@@ -2017,14 +1974,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             self.assertTrue(api_response[2].allowed)
             self.assertEqual(api_response[2].request, body3)
             # Make sure the API was called with the right data
-            mock_request.assert_any_call(
-                "GET",
-                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01GXSA8YR785C4FYS3C0RTG7B1",
-                headers=ANY,
-                query_params=[],
-                _preload_content=ANY,
-                _request_timeout=None,
-            )
             mock_request.assert_any_call(
                 "POST",
                 "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/check",
@@ -2093,7 +2042,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
 
         # First, mock the response
         mock_request.side_effect = [
-            mock_response("{}", 200),
             mock_response('{"allowed": true, "resolution": "1234"}', 200),
             ValidationException(http_resp=http_mock_response(response_body, 400)),
             mock_response('{"allowed": false, "resolution": "1234"}', 200),
@@ -2138,14 +2086,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             self.assertFalse(api_response[2].allowed)
             self.assertEqual(api_response[2].request, body3)
             # Make sure the API was called with the right data
-            mock_request.assert_any_call(
-                "GET",
-                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01GXSA8YR785C4FYS3C0RTG7B1",
-                headers=ANY,
-                query_params=[],
-                _preload_content=ANY,
-                _request_timeout=None,
-            )
             mock_request.assert_any_call(
                 "POST",
                 "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/check",
@@ -2357,7 +2297,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
 
         # First, mock the response
         mock_request.side_effect = [
-            mock_response("{}", 200),
             mock_response('{"allowed": true, "resolution": "1234"}', 200),
             mock_response('{"allowed": false, "resolution": "1234"}', 200),
             mock_response('{"allowed": true, "resolution": "1234"}', 200),
@@ -2376,14 +2315,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             self.assertEqual(api_response, ["reader", "viewer"])
 
             # Make sure the API was called with the right data
-            mock_request.assert_any_call(
-                "GET",
-                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01GXSA8YR785C4FYS3C0RTG7B1",
-                headers=ANY,
-                query_params=[],
-                _preload_content=ANY,
-                _request_timeout=None,
-            )
             mock_request.assert_any_call(
                 "POST",
                 "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/check",
@@ -2447,7 +2378,7 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
         configuration = self.configuration
         configuration.store_id = store_id
         async with OpenFgaClient(configuration) as api_client:
-            with self.assertRaises(UnauthorizedException) as api_exception:
+            with self.assertRaises(UnauthorizedException):
                 await api_client.list_relations(
                     body=ClientListRelationsRequest(
                         user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
@@ -2457,18 +2388,9 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                     options={"authorization_model_id": "01GXSA8YR785C4FYS3C0RTG7B1"},
                 )
 
-            self.assertIsInstance(api_exception.exception, UnauthorizedException)
             mock_request.assert_called()
-            self.assertEqual(mock_request.call_count, 1)
+            self.assertEqual(mock_request.call_count, 3)
 
-            mock_request.assert_called_once_with(
-                "GET",
-                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01GXSA8YR785C4FYS3C0RTG7B1",
-                headers=ANY,
-                query_params=[],
-                _preload_content=ANY,
-                _request_timeout=None,
-            )
             await api_client.close()
 
     @patch.object(rest.RESTClientObject, "request")

--- a/test/test_client_sync.py
+++ b/test/test_client_sync.py
@@ -974,7 +974,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             mock_response("{}", 200),
             mock_response("{}", 200),
             mock_response("{}", 200),
-            mock_response("{}", 200),
         ]
         configuration = self.configuration
         configuration.store_id = store_id
@@ -1043,15 +1042,7 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                     ),
                 ],
             )
-            self.assertEqual(mock_request.call_count, 4)
-            mock_request.assert_any_call(
-                "GET",
-                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01G5JAVJ41T49E9TT3SKVS7X1J",
-                headers=ANY,
-                query_params=[],
-                _preload_content=ANY,
-                _request_timeout=None,
-            )
+            self.assertEqual(mock_request.call_count, 3)
             mock_request.assert_any_call(
                 "POST",
                 "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/write",
@@ -1126,7 +1117,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             mock_response("{}", 200),
             mock_response("{}", 200),
             mock_response("{}", 200),
-            mock_response("{}", 200),
         ]
         configuration = self.configuration
         configuration.store_id = store_id
@@ -1195,15 +1185,7 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                     ),
                 ],
             )
-            self.assertEqual(mock_request.call_count, 4)
-            mock_request.assert_any_call(
-                "GET",
-                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01G5JAVJ41T49E9TT3SKVS7X1J",
-                headers=ANY,
-                query_params=[],
-                _preload_content=ANY,
-                _request_timeout=None,
-            )
+            self.assertEqual(mock_request.call_count, 3)
             mock_request.assert_any_call(
                 "POST",
                 "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/write",
@@ -1346,15 +1328,7 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                     ),
                 ],
             )
-            self.assertEqual(mock_request.call_count, 3)
-            mock_request.assert_any_call(
-                "GET",
-                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01G5JAVJ41T49E9TT3SKVS7X1J",
-                headers=ANY,
-                query_params=[],
-                _preload_content=ANY,
-                _request_timeout=None,
-            )
+            self.assertEqual(mock_request.call_count, 2)
             mock_request.assert_any_call(
                 "POST",
                 "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/write",
@@ -1417,7 +1391,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
         """
 
         mock_request.side_effect = [
-            mock_response("{}", 200),
             mock_response("{}", 200),
             ValidationException(http_resp=http_mock_response(response_body, 400)),
             mock_response("{}", 200),
@@ -1496,15 +1469,7 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                     error=None,
                 ),
             )
-            self.assertEqual(mock_request.call_count, 4)
-            mock_request.assert_any_call(
-                "GET",
-                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01G5JAVJ41T49E9TT3SKVS7X1J",
-                headers=ANY,
-                query_params=[],
-                _preload_content=ANY,
-                _request_timeout=None,
-            )
+            self.assertEqual(mock_request.call_count, 3)
             mock_request.assert_any_call(
                 "POST",
                 "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/write",
@@ -1577,7 +1542,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
         """
         mock_request.side_effect = [
             mock_response("{}", 200),
-            mock_response("{}", 200),
         ]
         configuration = self.configuration
         configuration.store_id = store_id
@@ -1602,14 +1566,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                     "authorization_model_id": "01G5JAVJ41T49E9TT3SKVS7X1J",
                     "transaction": transaction,
                 },
-            )
-            mock_request.assert_any_call(
-                "GET",
-                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01G5JAVJ41T49E9TT3SKVS7X1J",
-                headers=ANY,
-                query_params=[],
-                _preload_content=ANY,
-                _request_timeout=None,
             )
             mock_request.assert_any_call(
                 "POST",
@@ -1771,7 +1727,7 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
         configuration = self.configuration
         configuration.store_id = store_id
         with OpenFgaClient(configuration) as api_client:
-            with self.assertRaises(UnauthorizedException) as api_exception:
+            with self.assertRaises(UnauthorizedException):
                 body = ClientWriteRequest(
                     writes=[
                         ClientTuple(
@@ -1792,19 +1748,31 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                     },
                 )
 
-            self.assertIsInstance(api_exception.exception, UnauthorizedException)
-            mock_request.assert_called()
-            self.assertEqual(mock_request.call_count, 1)
+                mock_request.assert_called()
+                self.assertEqual(mock_request.call_count, 1)
 
-            mock_request.assert_called_once_with(
-                "GET",
-                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01G5JAVJ41T49E9TT3SKVS7X1J",
-                headers=ANY,
-                query_params=[],
-                _preload_content=ANY,
-                _request_timeout=None,
-            )
-            api_client.close()
+                mock_request.assert_called_once_with(
+                    "POST",
+                    "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/write",
+                    headers=ANY,
+                    query_params=[],
+                    post_params=[],
+                    body={
+                        "writes": {
+                            "tuple_keys": [
+                                {
+                                    "user": "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+                                    "relation": "reader",
+                                    "object": "document:2021-budget",
+                                }
+                            ]
+                        },
+                        "authorization_model_id": "01G5JAVJ41T49E9TT3SKVS7X1J",
+                    },
+                    _preload_content=ANY,
+                    _request_timeout=ANY,
+                )
+                api_client.close()
 
     @patch.object(rest.RESTClientObject, "request")
     def test_check(self, mock_request):
@@ -1918,7 +1886,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
         # First, mock the response
         response_body = '{"allowed": true, "resolution": "1234"}'
         mock_request.side_effect = [
-            mock_response("{}", 200),
             mock_response(response_body, 200),
         ]
         body = ClientCheckRequest(
@@ -1939,14 +1906,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             self.assertTrue(api_response[0].allowed)
             self.assertEqual(api_response[0].request, body)
             # Make sure the API was called with the right data
-            mock_request.assert_any_call(
-                "GET",
-                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01GXSA8YR785C4FYS3C0RTG7B1",
-                headers=ANY,
-                query_params=[],
-                _preload_content=ANY,
-                _request_timeout=None,
-            )
             mock_request.assert_any_call(
                 "POST",
                 "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/check",
@@ -1975,7 +1934,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
 
         # First, mock the response
         mock_request.side_effect = [
-            mock_response("{}", 200),
             mock_response('{"allowed": true, "resolution": "1234"}', 200),
             mock_response('{"allowed": false, "resolution": "1234"}', 200),
             mock_response('{"allowed": true, "resolution": "1234"}', 200),
@@ -2017,14 +1975,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             self.assertTrue(api_response[2].allowed)
             self.assertEqual(api_response[2].request, body3)
             # Make sure the API was called with the right data
-            mock_request.assert_any_call(
-                "GET",
-                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01GXSA8YR785C4FYS3C0RTG7B1",
-                headers=ANY,
-                query_params=[],
-                _preload_content=ANY,
-                _request_timeout=None,
-            )
             mock_request.assert_any_call(
                 "POST",
                 "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/check",
@@ -2093,7 +2043,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
 
         # First, mock the response
         mock_request.side_effect = [
-            mock_response("{}", 200),
             mock_response('{"allowed": true, "resolution": "1234"}', 200),
             ValidationException(http_resp=http_mock_response(response_body, 400)),
             mock_response('{"allowed": false, "resolution": "1234"}', 200),
@@ -2138,14 +2087,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             self.assertFalse(api_response[2].allowed)
             self.assertEqual(api_response[2].request, body3)
             # Make sure the API was called with the right data
-            mock_request.assert_any_call(
-                "GET",
-                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01GXSA8YR785C4FYS3C0RTG7B1",
-                headers=ANY,
-                query_params=[],
-                _preload_content=ANY,
-                _request_timeout=None,
-            )
             mock_request.assert_any_call(
                 "POST",
                 "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/check",
@@ -2357,7 +2298,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
 
         # First, mock the response
         mock_request.side_effect = [
-            mock_response("{}", 200),
             mock_response('{"allowed": true, "resolution": "1234"}', 200),
             mock_response('{"allowed": false, "resolution": "1234"}', 200),
             mock_response('{"allowed": true, "resolution": "1234"}', 200),
@@ -2376,14 +2316,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             self.assertEqual(api_response, ["reader", "viewer"])
 
             # Make sure the API was called with the right data
-            mock_request.assert_any_call(
-                "GET",
-                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01GXSA8YR785C4FYS3C0RTG7B1",
-                headers=ANY,
-                query_params=[],
-                _preload_content=ANY,
-                _request_timeout=None,
-            )
             mock_request.assert_any_call(
                 "POST",
                 "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/check",
@@ -2459,16 +2391,7 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
 
             self.assertIsInstance(api_exception.exception, UnauthorizedException)
             mock_request.assert_called()
-            self.assertEqual(mock_request.call_count, 1)
-
-            mock_request.assert_called_once_with(
-                "GET",
-                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01GXSA8YR785C4FYS3C0RTG7B1",
-                headers=ANY,
-                query_params=[],
-                _preload_content=ANY,
-                _request_timeout=None,
-            )
+            self.assertEqual(mock_request.call_count, 3)
             api_client.close()
 
     @patch.object(rest.RESTClientObject, "request")


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This pull request removes the `ReadAuthorizationModel` calls in `BatchCheck` and writes.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

- https://github.com/openfga/sdk-generator/issues/314

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
