### PR TITLE
fix: `list_users` should accept `FgaObject` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,6 +914,7 @@ List the users who have a certain relation to a particular type.
 
 ```python
 from openfga_sdk import OpenFgaClient
+from openfga_sdk.models.fga_object import FgaObject
 from openfga_sdk.client.models import ClientListUsersRequest, ClientTuple
 
 configuration = ClientConfiguration(
@@ -927,7 +928,7 @@ async with OpenFgaClient(configuration) as api_client:
     }
 
     request = ClientListUsersRequest(
-        object="document:2021-budget",
+        object=FgaObject(type="document", id="2021-budget"),
         relation="can_read",
         user_filters=[
             UserTypeFilter(type="user"),

--- a/example/example1/example1.py
+++ b/example/example1/example1.py
@@ -28,7 +28,9 @@ from openfga_sdk.client.models import (
     ClientWriteRequest,
     WriteTransactionOpts,
 )
+from openfga_sdk.client.models.list_users_request import ClientListUsersRequest
 from openfga_sdk.credentials import CredentialConfiguration, Credentials
+from openfga_sdk.models.fga_object import FgaObject
 
 
 async def main():
@@ -264,7 +266,7 @@ async def main():
         print(f"Allowed: {response.allowed}")
 
         # List objects with context
-        print("Listing objects  for access with context")
+        print("Listing objects for access with context")
 
         response = await fga_client.list_objects(
             ClientListObjectsRequest(
@@ -300,6 +302,20 @@ async def main():
             )
         )
         print(f"Relations: {response}")
+
+        # ListUsers
+        print("Listing user who have access to object")
+
+        response = await fga_client.list_objects(
+            ClientListUsersRequest(
+                relation="viewer",
+                object=FgaObject(type="document", id="roadmap"),
+                user_filters=[
+                    FgaObject(type="user"),
+                ],
+            )
+        )
+        print(f"Users: {response.objects}")
 
         # WriteAssertions
         await fga_client.write_assertions(

--- a/openfga_sdk/client/models/list_users_request.py
+++ b/openfga_sdk/client/models/list_users_request.py
@@ -11,6 +11,7 @@
 """
 
 from openfga_sdk.client.models.tuple import ClientTuple
+from openfga_sdk.models.fga_object import FgaObject
 from openfga_sdk.models.user_type_filter import UserTypeFilter
 
 
@@ -21,7 +22,7 @@ class ClientListUsersRequest:
 
     def __init__(
         self,
-        object: str = None,
+        object: FgaObject = None,
         relation: str = None,
         user_filters: list[UserTypeFilter] = None,
         contextual_tuples: list[ClientTuple] = None,
@@ -34,7 +35,7 @@ class ClientListUsersRequest:
         self._context = context
 
     @property
-    def object(self):
+    def object(self) -> FgaObject:
         """Gets the object of this ClientListUsersRequest.
 
 
@@ -44,7 +45,7 @@ class ClientListUsersRequest:
         return self._object
 
     @object.setter
-    def object(self, object):
+    def object(self, object: FgaObject):
         """Sets the object of this ClientListUsersRequest.
 
 
@@ -55,7 +56,7 @@ class ClientListUsersRequest:
         self._object = object
 
     @property
-    def relation(self):
+    def relation(self) -> str:
         """Gets the relation of this ClientListUsersRequest.
 
 
@@ -65,7 +66,7 @@ class ClientListUsersRequest:
         return self._relation
 
     @relation.setter
-    def relation(self, relation):
+    def relation(self, relation: str):
         """Sets the relation of this ClientListUsersRequest.
 
 
@@ -76,7 +77,7 @@ class ClientListUsersRequest:
         self._relation = relation
 
     @property
-    def user_filters(self):
+    def user_filters(self) -> list[UserTypeFilter]:
         """Gets the user_filters of this ClientListUsersRequest.
 
 
@@ -86,7 +87,7 @@ class ClientListUsersRequest:
         return self._user_filters
 
     @user_filters.setter
-    def user_filters(self, user_filters):
+    def user_filters(self, user_filters: list[UserTypeFilter]):
         """Sets the user_filters of this ClientListUsersRequest.
 
 
@@ -97,7 +98,7 @@ class ClientListUsersRequest:
         self._user_filters = user_filters
 
     @property
-    def contextual_tuples(self):
+    def contextual_tuples(self) -> list[ClientTuple]:
         """Gets the contextual_tuples of this ClientListUsersRequest.
 
 
@@ -107,7 +108,7 @@ class ClientListUsersRequest:
         return self._contextual_tuples
 
     @contextual_tuples.setter
-    def contextual_tuples(self, contextual_tuples):
+    def contextual_tuples(self, contextual_tuples: list[ClientTuple]):
         """Sets the contextual_tuples of this ClientListUsersRequest.
 
 
@@ -118,7 +119,7 @@ class ClientListUsersRequest:
         self._contextual_tuples = contextual_tuples
 
     @property
-    def context(self):
+    def context(self) -> object:
         """Gets the context of this ClientListUsersRequest.
 
         Additional request context that will be used to evaluate any ABAC conditions encountered in the query evaluation.
@@ -129,7 +130,7 @@ class ClientListUsersRequest:
         return self._context
 
     @context.setter
-    def context(self, context):
+    def context(self, context: object):
         """Sets the context of this ClientListUsersRequest.
 
         Additional request context that will be used to evaluate any ABAC conditions encountered in the query evaluation.

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -41,6 +41,7 @@ from openfga_sdk.models.check_response import CheckResponse
 from openfga_sdk.models.create_store_request import CreateStoreRequest
 from openfga_sdk.models.create_store_response import CreateStoreResponse
 from openfga_sdk.models.expand_response import ExpandResponse
+from openfga_sdk.models.fga_object import FgaObject
 from openfga_sdk.models.get_store_response import GetStoreResponse
 from openfga_sdk.models.leaf import Leaf
 from openfga_sdk.models.list_objects_response import ListObjectsResponse
@@ -2430,7 +2431,7 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
 
         async with OpenFgaClient(configuration) as api_client:
             body = ClientListUsersRequest(
-                object="document:2021-budget",
+                object=FgaObject(type="document", id="2021-budget"),
                 relation="can_read",
                 user_filters=[
                     UserTypeFilter(type="user"),
@@ -2487,7 +2488,7 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                 post_params=[],
                 body={
                     "authorization_model_id": "01G5JAVJ41T49E9TT3SKVS7X1J",
-                    "object": "document:2021-budget",
+                    "object": {"id": "2021-budget", "type": "document"},
                     "relation": "can_read",
                     "user_filters": [
                         {"type": "user"},

--- a/test/test_client_sync.py
+++ b/test/test_client_sync.py
@@ -39,6 +39,7 @@ from openfga_sdk.models.check_response import CheckResponse
 from openfga_sdk.models.create_store_request import CreateStoreRequest
 from openfga_sdk.models.create_store_response import CreateStoreResponse
 from openfga_sdk.models.expand_response import ExpandResponse
+from openfga_sdk.models.fga_object import FgaObject
 from openfga_sdk.models.get_store_response import GetStoreResponse
 from openfga_sdk.models.leaf import Leaf
 from openfga_sdk.models.list_objects_response import ListObjectsResponse
@@ -2431,7 +2432,7 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
 
         with OpenFgaClient(configuration) as api_client:
             body = ClientListUsersRequest()
-            body.object = "document:2021-budget"
+            body.object = FgaObject(type="document", id="2021-budget")
             body.relation = "can_read"
             body.user_filters = [
                 UserTypeFilter(type="user"),
@@ -2487,7 +2488,7 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                 post_params=[],
                 body={
                     "authorization_model_id": "01G5JAVJ41T49E9TT3SKVS7X1J",
-                    "object": "document:2021-budget",
+                    "object": {"id": "2021-budget", "type": "document"},
                     "relation": "can_read",
                     "user_filters": [
                         {"type": "user"},


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This pull request fixes the `ClientListUsersRequest` class, which incorrectly accepts a `str` type for `object` rather than an `FgaObject` assignment. For consistency's sake, it also improves the type hinting of the other class properties.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

- Resolves #97 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
