### PR TITLE
Fix: ClientTuple condition property type

### DIFF
--- a/openfga_sdk/client/models/tuple.py
+++ b/openfga_sdk/client/models/tuple.py
@@ -24,7 +24,7 @@ class ClientTuple:
         user: str,
         relation: str,
         object: str,
-        condition: RelationshipCondition = None,
+        condition: RelationshipCondition | None = None,
     ):
         self._user = user
         self._relation = relation


### PR DESCRIPTION


<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

Changes type of condition property on ClientTuple

## Description
ClientTuple's property condition is by default set to None - indicating it is nullable. 
It's type does not reflect that however. Therefore I have simply added a union between the existing typ RelationshipCondition and None.


## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ X] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X ] The correct base branch is being used, if not `main`
- [X ] I have added tests to validate that the change in functionality is working as expected
