### PR TITLE
fix: OpenTelemetry bugfixes

### DIFF
--- a/openfga_sdk/sync/api_client.py
+++ b/openfga_sdk/sync/api_client.py
@@ -311,12 +311,12 @@ class ApiClient:
 
             self._telemetry.metrics().queryDuration(
                 attributes=_telemetry_attributes,
-                configuration=self.configuration,
+                configuration=self.configuration.telemetry,
             )
 
             self._telemetry.metrics().requestDuration(
                 attributes=_telemetry_attributes,
-                configuration=self.configuration,
+                configuration=self.configuration.telemetry,
             )
 
             if not _preload_content:

--- a/openfga_sdk/telemetry/metrics.py
+++ b/openfga_sdk/telemetry/metrics.py
@@ -122,11 +122,27 @@ class MetricsTelemetry:
             configuration = TelemetryConfiguration()
 
         if (
-            isinstance(configuration, TelemetryMetricsConfiguration) is False
+            isinstance(configuration, TelemetryConfiguration) is False
             or configuration.metrics.histogram_request_duration.enabled is False
             or configuration.metrics.histogram_request_duration.attributes() == {}
         ):
             return self.histogram(TelemetryHistograms.request_duration)
+
+        if (
+            value is None
+            and TelemetryAttributes.http_client_request_duration.name in attributes
+        ):
+            value = attributes[TelemetryAttributes.http_client_request_duration.name]
+            attributes.pop(TelemetryAttributes.http_client_request_duration.name, None)
+
+        if value is not None:
+            try:
+                value = int(value)
+                attributes[TelemetryAttributes.http_client_request_duration.name] = (
+                    value
+                )
+            except ValueError:
+                value = None
 
         attributes = TelemetryAttributes().prepare(
             attributes,
@@ -138,6 +154,9 @@ class MetricsTelemetry:
             and TelemetryAttributes.http_client_request_duration.name in attributes
         ):
             value = attributes[TelemetryAttributes.http_client_request_duration.name]
+
+        if value is None:
+            return self.histogram(TelemetryHistograms.request_duration)
 
         return self.histogram(TelemetryHistograms.request_duration, value, attributes)
 
@@ -151,21 +170,34 @@ class MetricsTelemetry:
             configuration = TelemetryConfiguration()
 
         if (
-            isinstance(configuration, TelemetryMetricsConfiguration) is False
+            isinstance(configuration, TelemetryConfiguration) is False
             or configuration.metrics.histogram_query_duration.enabled is False
             or configuration.metrics.histogram_query_duration.attributes() == {}
         ):
             return self.histogram(TelemetryHistograms.query_duration)
-
-        attributes = TelemetryAttributes().prepare(
-            attributes,
-            filter=configuration.metrics.histogram_query_duration.attributes(),
-        )
 
         if (
             value is None
             and TelemetryAttributes.http_server_request_duration.name in attributes
         ):
             value = attributes[TelemetryAttributes.http_server_request_duration.name]
+            attributes.pop(TelemetryAttributes.http_server_request_duration.name, None)
+
+        if value is not None:
+            try:
+                value = int(value)
+                attributes[TelemetryAttributes.http_server_request_duration.name] = (
+                    value
+                )
+            except ValueError:
+                value = None
+
+        attributes = TelemetryAttributes().prepare(
+            attributes,
+            filter=configuration.metrics.histogram_query_duration.attributes(),
+        )
+
+        if value is None:
+            return self.histogram(TelemetryHistograms.query_duration)
 
         return self.histogram(TelemetryHistograms.query_duration, value, attributes)

--- a/test/telemetry/attributes_test.py
+++ b/test/telemetry/attributes_test.py
@@ -40,6 +40,16 @@ def test_prepare_with_none_attributes(telemetry_attributes):
     assert prepared == {}
 
 
+def test_prepare_with_invalid_attributes(telemetry_attributes):
+    attributes = {
+        "invalid_attribute": "value",
+    }
+    filters = [telemetry_attributes.fga_client_request_client_id]
+
+    with pytest.raises(ValueError):
+        telemetry_attributes.prepare(attributes, filter=filters)
+
+
 def test_from_request_with_all_params(telemetry_attributes):
     credentials = Credentials(
         method="client_credentials",


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This PR fixes several bugs identified in the recent OpenTelemetry improvements:

- Fixed `http_client_request_duration` being reported in seconds rather than the intended milliseconds
- Fixed the sync client mistakenly passing the entire configuration (rather than just the OpenTelemetry configuration as intended) to `queryDuration()` and `requestDuration()`.
- Fixed an issue in which some attributes may not have been exported as expected under some conditions
- All attribute values are now correctly exported as their intended types rather than defaulting to strings
- Fixed an issue in which `queryDuration()` and `requestDuration()` may not have updated their histograms reliably when `attr_http_client_request_duration` or `attr_http_server_request_duration` (respectively) were not enabled (which is the default)

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
