### PR TITLE
fix: inconsistence in 429 handling between sync/async client

### DIFF
--- a/openfga_sdk/rest.py
+++ b/openfga_sdk/rest.py
@@ -27,6 +27,7 @@ from openfga_sdk.exceptions import (
     RateLimitExceededError,
     ServiceException,
     UnauthorizedException,
+    ValidationException,
 )
 
 logger = logging.getLogger(__name__)
@@ -174,6 +175,9 @@ class RESTClientObject:
             logger.debug("response body: %s", r.data)
 
             if not 200 <= r.status <= 299:
+                if r.status == 400:
+                    raise ValidationException(http_resp=r)
+
                 if r.status == 401:
                     raise UnauthorizedException(http_resp=r)
 

--- a/openfga_sdk/sync/rest.py
+++ b/openfga_sdk/sync/rest.py
@@ -24,6 +24,7 @@ from openfga_sdk.exceptions import (
     ApiValueError,
     ForbiddenException,
     NotFoundException,
+    RateLimitExceededError,
     ServiceException,
     UnauthorizedException,
     ValidationException,
@@ -251,6 +252,9 @@ class RESTClientObject:
 
             if r.status == 404:
                 raise NotFoundException(http_resp=r)
+
+            if r.status == 429:
+                raise RateLimitExceededError(http_resp=r)
 
             if 500 <= r.status <= 599:
                 raise ServiceException(http_resp=r)


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This change addresses inconsistencies between the sync and async clients when encountering HTTP status codes 429 or 400 in an HTTP response.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

Closes #129 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
