### PR TITLE
fix: ensure `max_parallel_requests` is an `int` value in `batch_check`

### DIFF
--- a/openfga_sdk/client/client.py
+++ b/openfga_sdk/client/client.py
@@ -612,7 +612,7 @@ class OpenFgaClient:
             semaphore.release()
 
     async def batch_check(
-        self, body: list[ClientCheckRequest], options: dict[str, str] = None
+        self, body: list[ClientCheckRequest], options: dict[str, str | int] = None
     ):
         """
         Run a set of checks
@@ -631,7 +631,13 @@ class OpenFgaClient:
 
         max_parallel_requests = 10
         if options is not None and "max_parallel_requests" in options:
-            max_parallel_requests = options["max_parallel_requests"]
+            if (
+                isinstance(options["max_parallel_requests"], str)
+                and options["max_parallel_requests"].isdigit()
+            ):
+                max_parallel_requests = int(options["max_parallel_requests"])
+            elif isinstance(options["max_parallel_requests"], int):
+                max_parallel_requests = options["max_parallel_requests"]
 
         sem = asyncio.Semaphore(max_parallel_requests)
         batch_check_coros = [

--- a/openfga_sdk/sync/client/client.py
+++ b/openfga_sdk/sync/client/client.py
@@ -599,7 +599,7 @@ class OpenFgaClient:
             )
 
     def batch_check(
-        self, body: list[ClientCheckRequest], options: dict[str, str] = None
+        self, body: list[ClientCheckRequest], options: dict[str, str | int] = None
     ):
         """
         Run a set of checks
@@ -619,7 +619,13 @@ class OpenFgaClient:
 
         max_parallel_requests = 10
         if options is not None and "max_parallel_requests" in options:
-            max_parallel_requests = options["max_parallel_requests"]
+            if (
+                isinstance(options["max_parallel_requests"], str)
+                and options["max_parallel_requests"].isdigit()
+            ):
+                max_parallel_requests = int(options["max_parallel_requests"])
+            elif isinstance(options["max_parallel_requests"], int):
+                max_parallel_requests = options["max_parallel_requests"]
 
         batch_check_response = []
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This change addresses a bug where `batch_check` typing was configured to only accept `str`ing values as part of the `options` `dict`; however, the `max_parallel_requests` option (later used by the `ThreadPoolExecutor`) requires this to be an `int`eger value.

This PR:
- Updates the method signature to accept `str | int` as values for the `dict`.
- Adds a check to determine if `max_parallel_requests` was passed as an `str` or `int.`
  - if it was passed as a `str`, and Python verifies the string represents a numerical value (using `isdigit()`), then the value is cast to an `int` and used.
  - If it was passed as an `int,` the value is used.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

closes #128 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
