### PR TITLE
fix: correct usage of the sdk method header

### DIFF
--- a/openfga_sdk/client/client.py
+++ b/openfga_sdk/client/client.py
@@ -206,7 +206,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
         # convert options to kwargs
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ListStores")
         kwargs = options_to_kwargs(options)
         api_response = await self._api.list_stores(
             **kwargs,
@@ -223,7 +222,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "CreateStore")
         kwargs = options_to_kwargs(options)
         api_response = await self._api.create_store(body, **kwargs)
         return api_response
@@ -236,7 +234,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "GetStore")
         kwargs = options_to_kwargs(options)
         api_response = await self._api.get_store(
             **kwargs,
@@ -251,7 +248,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "DeleteStore")
         kwargs = options_to_kwargs(options)
         api_response = await self._api.delete_store(
             **kwargs,
@@ -270,9 +266,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(
-            options, CLIENT_METHOD_HEADER, "ReadAuthorizationModels"
-        )
         kwargs = options_to_kwargs(options)
         api_response = await self._api.read_authorization_models(
             **kwargs,
@@ -290,9 +283,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(
-            options, CLIENT_METHOD_HEADER, "WriteAuthorizationModel"
-        )
         kwargs = options_to_kwargs(options)
         api_response = await self._api.write_authorization_model(
             body,
@@ -308,9 +298,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(
-            options, CLIENT_METHOD_HEADER, "ReadAuthorizationModel"
-        )
         kwargs = options_to_kwargs(options)
         authorization_model_id = self._get_authorization_model_id(options)
         api_response = await self._api.read_authorization_model(
@@ -330,7 +317,7 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
         options = set_heading_if_not_set(
-            options, CLIENT_METHOD_HEADER, "ReadLatestAuthoriationModel"
+            options, CLIENT_METHOD_HEADER, "ReadLatestAuthorizationModel"
         )
         options["page_size"] = 1
         api_response = await self.read_authorization_models(options)
@@ -353,7 +340,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ReadChanges")
         kwargs = options_to_kwargs(options)
         kwargs["type"] = body.type
         api_response = await self._api.read_changes(
@@ -373,7 +359,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "Read")
         page_size = None
         continuation_token = None
         if options:
@@ -494,7 +479,7 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "Writes")
+        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "Write")
         transaction = options_to_transaction_info(options)
         if not transaction.disabled:
             results = await self._write_with_transaction(body, options)
@@ -561,8 +546,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "Check")
-
         kwargs = options_to_kwargs(options)
 
         req_body = CheckRequest(
@@ -658,7 +641,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "Expand")
         kwargs = options_to_kwargs(options)
 
         req_body = ExpandRequest(
@@ -685,7 +667,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ListObjects")
         kwargs = options_to_kwargs(options)
 
         req_body = ListObjectsRequest(
@@ -750,7 +731,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ListUsers")
         kwargs = options_to_kwargs(options)
 
         req_body = ListUsersRequest(
@@ -784,9 +764,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(
-            options, CLIENT_METHOD_HEADER, "ReadAssertions"
-        )
 
         kwargs = options_to_kwargs(options)
         authorization_model_id = self._get_authorization_model_id(options)
@@ -805,9 +782,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(
-            options, CLIENT_METHOD_HEADER, "WriteAssertions"
-        )
         kwargs = options_to_kwargs(options)
         authorization_model_id = self._get_authorization_model_id(options)
 

--- a/openfga_sdk/sync/client/client.py
+++ b/openfga_sdk/sync/client/client.py
@@ -206,7 +206,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
         # convert options to kwargs
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ListStores")
         kwargs = options_to_kwargs(options)
         api_response = self._api.list_stores(
             **kwargs,
@@ -223,7 +222,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "CreateStore")
         kwargs = options_to_kwargs(options)
         api_response = self._api.create_store(body, **kwargs)
         return api_response
@@ -236,7 +234,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "GetStore")
         kwargs = options_to_kwargs(options)
         api_response = self._api.get_store(
             **kwargs,
@@ -251,7 +248,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "DeleteStore")
         kwargs = options_to_kwargs(options)
         api_response = self._api.delete_store(
             **kwargs,
@@ -270,9 +266,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(
-            options, CLIENT_METHOD_HEADER, "ReadAuthorizationModels"
-        )
         kwargs = options_to_kwargs(options)
         api_response = self._api.read_authorization_models(
             **kwargs,
@@ -290,9 +283,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(
-            options, CLIENT_METHOD_HEADER, "WriteAuthorizationModel"
-        )
         kwargs = options_to_kwargs(options)
         api_response = self._api.write_authorization_model(
             body,
@@ -308,9 +298,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(
-            options, CLIENT_METHOD_HEADER, "ReadAuthorizationModel"
-        )
         kwargs = options_to_kwargs(options)
         authorization_model_id = self._get_authorization_model_id(options)
         api_response = self._api.read_authorization_model(
@@ -328,7 +315,7 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
         options = set_heading_if_not_set(
-            options, CLIENT_METHOD_HEADER, "ReadLatestAuthoriationModel"
+            options, CLIENT_METHOD_HEADER, "ReadLatestAuthorizationModel"
         )
         options["page_size"] = 1
         api_response = self.read_authorization_models(options)
@@ -351,7 +338,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ReadChanges")
         kwargs = options_to_kwargs(options)
         kwargs["type"] = body.type
         api_response = self._api.read_changes(
@@ -371,7 +357,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "Read")
         page_size = None
         continuation_token = None
         if options:
@@ -554,8 +539,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "Check")
-
         kwargs = options_to_kwargs(options)
 
         req_body = CheckRequest(
@@ -649,7 +632,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "Expand")
         kwargs = options_to_kwargs(options)
 
         req_body = ExpandRequest(
@@ -676,7 +658,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ListObjects")
         kwargs = options_to_kwargs(options)
 
         req_body = ListObjectsRequest(
@@ -739,7 +720,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ListUsers")
         kwargs = options_to_kwargs(options)
 
         req_body = ListUsersRequest(
@@ -773,9 +753,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(
-            options, CLIENT_METHOD_HEADER, "ReadAssertions"
-        )
 
         kwargs = options_to_kwargs(options)
         authorization_model_id = self._get_authorization_model_id(options)
@@ -794,9 +771,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(
-            options, CLIENT_METHOD_HEADER, "WriteAssertions"
-        )
         kwargs = options_to_kwargs(options)
         authorization_model_id = self._get_authorization_model_id(options)
 


### PR DESCRIPTION
## Description


Currently the Python SDK is sending the sdk method header for all requests, the expectation (and behaviour in other SDKs) for this header is that it is only sent for SDK methods that are wrappers of APIs as the intent is to provide a way for implementors of OpenFGA to track usage of these SDK wrapper methods.

So it should be sent for:

- `read_latest_authorization_model`
- `write`
  - Should also send `CLIENT_BULK_REQUEST_ID_HEADER` when not in transaction mode
- `write_tuples`
  - Should also send `CLIENT_BULK_REQUEST_ID_HEADER` when not in transaction mode (handled via `write`)
- `delete_tuples`
  - Should also send `CLIENT_BULK_REQUEST_ID_HEADER` when not in transaction mode (handled via `write`)
- `batch_check`
-   - Should also send `CLIENT_BULK_REQUEST_ID_HEADER`
- `list_relations`
  - Should also send `CLIENT_BULK_REQUEST_ID_HEADER` when not in transaction mode



## References

https://github.com/openfga/sdk-generator/pull/435

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
