### PR TITLE
Minor fixes

### DIFF
--- a/example/example1/example1.py
+++ b/example/example1/example1.py
@@ -16,6 +16,7 @@ from openfga_sdk import (
     TypeDefinition,
     Userset,
     Usersets,
+    UserTypeFilter,
     WriteAuthorizationModelRequest,
 )
 from openfga_sdk.client.models import (
@@ -306,16 +307,17 @@ async def main():
         # ListUsers
         print("Listing user who have access to object")
 
-        response = await fga_client.list_objects(
+        response = await fga_client.list_users(
             ClientListUsersRequest(
                 relation="viewer",
                 object=FgaObject(type="document", id="roadmap"),
                 user_filters=[
-                    FgaObject(type="user"),
+                    UserTypeFilter(type="user"),
                 ],
+                context=dict(ViewCount=100),
             )
         )
-        print(f"Users: {response.objects}")
+        print(f"Users: {response.users}")
 
         # WriteAssertions
         await fga_client.write_assertions(

--- a/openfga_sdk/client/client.py
+++ b/openfga_sdk/client/client.py
@@ -744,9 +744,7 @@ class OpenFgaClient:
         )
 
         if body.contextual_tuples:
-            req_body.contextual_tuples = ContextualTupleKeys(
-                tuple_keys=convert_tuple_keys(body.contextual_tuples)
-            )
+            req_body.contextual_tuples = convert_tuple_keys(body.contextual_tuples)
 
         api_response = await self._api.list_users(body=req_body, **kwargs)
 

--- a/openfga_sdk/client/client.py
+++ b/openfga_sdk/client/client.py
@@ -321,7 +321,12 @@ class OpenFgaClient:
         )
         options["page_size"] = 1
         api_response = await self.read_authorization_models(options)
-        return ReadAuthorizationModelResponse(api_response.authorization_models[0])
+        model = (
+            api_response.authorization_models[0]
+            if len(api_response.authorization_models) > 0
+            else None
+        )
+        return ReadAuthorizationModelResponse(model)
 
     #######################
     # Relationship Tuples

--- a/openfga_sdk/sync/client/client.py
+++ b/openfga_sdk/sync/client/client.py
@@ -733,9 +733,7 @@ class OpenFgaClient:
         )
 
         if body.contextual_tuples:
-            req_body.contextual_tuples = ContextualTupleKeys(
-                tuple_keys=convert_tuple_keys(body.contextual_tuples)
-            )
+            req_body.contextual_tuples = convert_tuple_keys(body.contextual_tuples)
 
         api_response = self._api.list_users(body=req_body, **kwargs)
 

--- a/openfga_sdk/sync/client/client.py
+++ b/openfga_sdk/sync/client/client.py
@@ -319,7 +319,12 @@ class OpenFgaClient:
         )
         options["page_size"] = 1
         api_response = self.read_authorization_models(options)
-        return ReadAuthorizationModelResponse(api_response.authorization_models[0])
+        model = (
+            api_response.authorization_models[0]
+            if len(api_response.authorization_models) > 0
+            else None
+        )
+        return ReadAuthorizationModelResponse(model)
 
     #######################
     # Relationship Tuples

--- a/test/client/client_test.py
+++ b/test/client/client_test.py
@@ -2523,20 +2523,18 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                         {"type": "user"},
                         {"type": "team", "relation": "member"},
                     ],
-                    "contextual_tuples": {
-                        "tuple_keys": [
-                            {
-                                "user": "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
-                                "relation": "editor",
-                                "object": "folder:product",
-                            },
-                            {
-                                "user": "folder:product",
-                                "relation": "parent",
-                                "object": "document:roadmap",
-                            },
-                        ]
-                    },
+                    "contextual_tuples": [
+                        {
+                            "user": "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+                            "relation": "editor",
+                            "object": "folder:product",
+                        },
+                        {
+                            "user": "folder:product",
+                            "relation": "parent",
+                            "object": "document:roadmap",
+                        },
+                    ],
                     "context": {},
                     "consistency": "MINIMIZE_LATENCY",
                 },

--- a/test/sync/client/client_test.py
+++ b/test/sync/client/client_test.py
@@ -2526,20 +2526,18 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                         {"type": "user"},
                         {"type": "team", "relation": "member"},
                     ],
-                    "contextual_tuples": {
-                        "tuple_keys": [
-                            {
-                                "user": "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
-                                "relation": "editor",
-                                "object": "folder:product",
-                            },
-                            {
-                                "user": "folder:product",
-                                "relation": "parent",
-                                "object": "document:roadmap",
-                            },
-                        ]
-                    },
+                    "contextual_tuples": [
+                        {
+                            "user": "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+                            "relation": "editor",
+                            "object": "folder:product",
+                        },
+                        {
+                            "user": "folder:product",
+                            "relation": "parent",
+                            "object": "document:roadmap",
+                        },
+                    ],
                     "context": {},
                     "consistency": "MINIMIZE_LATENCY",
                 },

--- a/test/sync/client/client_test.py
+++ b/test/sync/client/client_test.py
@@ -615,6 +615,36 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             )
 
     @patch.object(rest.RESTClientObject, "request")
+    def test_read_latest_authorization_model_with_no_models(self, mock_request):
+        """Test case for read_latest_authorization_model when no models are in the store
+
+        Return the latest authorization models configured for the store
+        """
+        response_body = """
+{
+  "authorization_models": []
+}
+        """
+        mock_request.return_value = mock_response(response_body, 200)
+        configuration = self.configuration
+        configuration.store_id = store_id
+        # Enter a context with an instance of the API client
+        with OpenFgaClient(configuration) as api_client:
+
+            # Return a particular version of an authorization model
+            api_response = api_client.read_latest_authorization_model(options={})
+            self.assertIsInstance(api_response, ReadAuthorizationModelResponse)
+            self.assertIsNone(api_response.authorization_model)
+            mock_request.assert_called_once_with(
+                "GET",
+                "http://api.fga.example/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models",
+                headers=ANY,
+                query_params=[("page_size", 1)],
+                _preload_content=ANY,
+                _request_timeout=None,
+            )
+
+    @patch.object(rest.RESTClientObject, "request")
     def test_read_changes(self, mock_request):
         """Test case for read_changes
 
@@ -2464,7 +2494,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             body.relation = "can_read"
             body.user_filters = [
                 UserTypeFilter(type="user"),
-                UserTypeFilter(type="team", relation="member"),
             ]
             body.context = {}
             body.contextual_tuples = [
@@ -2524,7 +2553,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                     "relation": "can_read",
                     "user_filters": [
                         {"type": "user"},
-                        {"type": "team", "relation": "member"},
                     ],
                     "contextual_tuples": [
                         {


### PR DESCRIPTION
## Description

This PR fixes some minor issues I noticed while updating the `openfga/api` sha on `main. Splitting out to a separate PR to help review.

They are as follows:

- the `ListUsers` API differs on the shape of `contextual_tuples`, rather than an object with a `tuple_keys` property it just takes the array directly. So we don't need the `ContextualTupleKeys` type
- `read_latest_authorization_model` errors if there are no models
- `list_users` in the example was using the wrong types

## References

https://github.com/openfga/sdk-generator/pull/446

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
