### PR TITLE
chore: remove Optional typings

### DIFF
--- a/openfga_sdk/configuration.py
+++ b/openfga_sdk/configuration.py
@@ -15,7 +15,6 @@ import http
 import logging
 import sys
 import urllib
-from typing import Optional
 
 import urllib3
 
@@ -193,7 +192,7 @@ class Configuration:
         server_operation_variables=None,
         ssl_ca_cert=None,
         api_url=None,  # TODO: restructure when removing api_scheme/api_host
-        telemetry: Optional[
+        telemetry: (
             dict[
                 TelemetryConfigurationType | str,
                 TelemetryMetricsConfiguration
@@ -205,7 +204,8 @@ class Configuration:
                 ]
                 | None,
             ]
-        ] = None,
+            | None
+        ) = None,
     ):
         """Constructor"""
         self._url = api_url

--- a/openfga_sdk/telemetry/attributes.py
+++ b/openfga_sdk/telemetry/attributes.py
@@ -1,6 +1,6 @@
 import time
 import urllib
-from typing import NamedTuple, Optional
+from typing import NamedTuple
 
 from aiohttp import ClientResponse
 from urllib3 import HTTPResponse
@@ -89,7 +89,7 @@ class TelemetryAttributes:
 
     @staticmethod
     def get(
-        name: Optional[str] = None,
+        name: str | None = None,
     ) -> list[TelemetryAttribute] | TelemetryAttribute | None:
         if name is None:
             return TelemetryAttributes._attributes
@@ -234,11 +234,11 @@ class TelemetryAttributes:
 
     @staticmethod
     def fromResponse(
-        response: Optional[
-            HTTPResponse | RESTResponse | ClientResponse | ApiException
-        ] = None,
-        credentials: Optional[Credentials] = None,
-        attributes: Optional[dict[TelemetryAttribute, str | int]] = None,
+        response: (
+            HTTPResponse | RESTResponse | ClientResponse | ApiException | None
+        ) = None,
+        credentials: Credentials | None = None,
+        attributes: dict[TelemetryAttribute, str | int] | None = None,
     ) -> dict[TelemetryAttribute, str | int]:
         response_model_id = None
         response_query_duration = None
@@ -295,8 +295,8 @@ class TelemetryAttributes:
     @staticmethod
     def coalesceAttributeValue(
         attribute: TelemetryAttribute,
-        value: Optional[int | float] = None,
-        attributes: Optional[dict[TelemetryAttribute, str | int]] = None,
+        value: int | float | None = None,
+        attributes: dict[TelemetryAttribute, str | int] | None = None,
     ) -> int | float | None:
         if value is None:
             if attribute in attributes:

--- a/openfga_sdk/telemetry/configuration.py
+++ b/openfga_sdk/telemetry/configuration.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Optional
+from typing import NamedTuple
 
 from openfga_sdk.telemetry.attributes import TelemetryAttribute, TelemetryAttributes
 from openfga_sdk.telemetry.counters import TelemetryCounter, TelemetryCounters
@@ -16,22 +16,22 @@ class TelemetryMetricConfiguration:
 
     def __init__(
         self,
-        config: Optional[dict[TelemetryAttribute, bool]] = None,
-        fga_client_request_client_id: Optional[bool] = None,
-        fga_client_request_method: Optional[bool] = None,
-        fga_client_request_model_id: Optional[bool] = None,
-        fga_client_request_store_id: Optional[bool] = None,
-        fga_client_response_model_id: Optional[bool] = None,
-        fga_client_user: Optional[bool] = None,
-        http_client_request_duration: Optional[bool] = None,
-        http_host: Optional[bool] = None,
-        http_request_method: Optional[bool] = None,
-        http_request_resend_count: Optional[bool] = None,
-        http_response_status_code: Optional[bool] = None,
-        http_server_request_duration: Optional[bool] = None,
-        url_scheme: Optional[bool] = None,
-        url_full: Optional[bool] = None,
-        user_agent_original: Optional[bool] = None,
+        config: dict[TelemetryAttribute, bool] | None = None,
+        fga_client_request_client_id: bool | None = None,
+        fga_client_request_method: bool | None = None,
+        fga_client_request_model_id: bool | None = None,
+        fga_client_request_store_id: bool | None = None,
+        fga_client_response_model_id: bool | None = None,
+        fga_client_user: bool | None = None,
+        http_client_request_duration: bool | None = None,
+        http_host: bool | None = None,
+        http_request_method: bool | None = None,
+        http_request_resend_count: bool | None = None,
+        http_response_status_code: bool | None = None,
+        http_server_request_duration: bool | None = None,
+        url_scheme: bool | None = None,
+        url_full: bool | None = None,
+        user_agent_original: bool | None = None,
     ):
         """
         Initialize a new instance of the `TelemetryMetricConfiguration` class.
@@ -468,8 +468,8 @@ class TelemetryMetricConfiguration:
 
     def configure(
         self,
-        config: Optional[dict[TelemetryAttribute | str, bool]] = None,
-        clear: Optional[bool] = False,
+        config: dict[TelemetryAttribute | str, bool] | None = None,
+        clear: bool | None = False,
     ) -> None:
         """
         Configure the telemetry metric.
@@ -509,7 +509,7 @@ class TelemetryMetricConfiguration:
             self._valid = None
 
     def getAttributes(
-        self, filter_enabled: Optional[bool] = True
+        self, filter_enabled: bool | None = True
     ) -> dict[TelemetryAttribute, bool]:
         """
         Returns a list of supported attributes. If `filter_enabled` is `True`, only enabled attributes are returned.
@@ -530,7 +530,7 @@ class TelemetryMetricConfiguration:
 
         return attributes
 
-    def isEnabled(self, attribute: Optional[TelemetryAttribute] = None) -> bool:
+    def isEnabled(self, attribute: TelemetryAttribute | None = None) -> bool:
         """
         Check if this metric is enabled for telemetry, based on whether any attributes are enabled.
 
@@ -547,7 +547,7 @@ class TelemetryMetricConfiguration:
 
         return False
 
-    def isValid(self, raise_exception: Optional[bool] = False) -> bool:
+    def isValid(self, raise_exception: bool = False) -> bool:
         """
         Validate the telemetry metric configuration.
 
@@ -604,16 +604,17 @@ class TelemetryMetricsConfiguration:
 
     def __init__(
         self,
-        config: Optional[
+        config: (
             dict[
                 TelemetryHistogram | TelemetryCounter,
                 TelemetryMetricConfiguration | None,
             ]
-        ] = None,
-        fga_client_credentials_request: Optional[TelemetryMetricConfiguration] = None,
-        fga_client_request_duration: Optional[TelemetryMetricConfiguration] = None,
-        fga_client_query_duration: Optional[TelemetryMetricConfiguration] = None,
-        fga_client_request: Optional[TelemetryMetricConfiguration] = None,
+            | None
+        ) = None,
+        fga_client_credentials_request: TelemetryMetricConfiguration | None = None,
+        fga_client_request_duration: TelemetryMetricConfiguration | None = None,
+        fga_client_query_duration: TelemetryMetricConfiguration | None = None,
+        fga_client_request: TelemetryMetricConfiguration | None = None,
     ):
         """
         Initialize a new instance of the `TelemetryMetricsConfiguration` class.
@@ -749,13 +750,14 @@ class TelemetryMetricsConfiguration:
 
     def configure(
         self,
-        config: Optional[
+        config: (
             dict[
                 TelemetryHistogram | TelemetryCounter | str,
                 TelemetryMetricConfiguration | dict[TelemetryAttribute, bool] | None,
             ]
-        ] = None,
-        clear: Optional[bool] = False,
+            | None
+        ) = None,
+        clear: bool = False,
     ) -> None:
         """
         Configure metrics reporting for telemetry.
@@ -801,7 +803,7 @@ class TelemetryMetricsConfiguration:
         self._valid = None
 
     def getMetrics(
-        self, filter_enabled: Optional[bool] = True
+        self, filter_enabled: bool = True
     ) -> dict[
         TelemetryHistogram | TelemetryCounter, TelemetryMetricConfiguration | None
     ]:
@@ -825,7 +827,7 @@ class TelemetryMetricsConfiguration:
         return metrics
 
     def isEnabled(
-        self, metric: Optional[TelemetryCounter | TelemetryHistogram] = None
+        self, metric: TelemetryCounter | TelemetryHistogram | None = None
     ) -> bool:
         """
         Check if a metric is enabled for telemetry.
@@ -847,7 +849,7 @@ class TelemetryMetricsConfiguration:
 
         return False
 
-    def isValid(self, raise_exception: Optional[bool] = False) -> bool:
+    def isValid(self, raise_exception: bool = False) -> bool:
         """
         Validate the telemetry metrics configuration.
 
@@ -903,7 +905,7 @@ class TelemetryConfigurations:
 
     @staticmethod
     def get(
-        name: Optional[str] = None,
+        name: str | None = None,
     ) -> list[TelemetryConfigurationType] | TelemetryConfigurationType | None:
         if name is None:
             return TelemetryConfigurations._configurations
@@ -921,8 +923,8 @@ class TelemetryConfiguration:
 
     def __init__(
         self,
-        config: Optional[dict[str, TelemetryMetricsConfiguration | None]] = None,
-        metrics: Optional[TelemetryMetricsConfiguration] = None,
+        config: dict[str, TelemetryMetricsConfiguration | None] | None = None,
+        metrics: TelemetryMetricsConfiguration | None = None,
     ):
         """
         Initialize a new instance of the `TelemetryConfiguration` class.
@@ -974,7 +976,7 @@ class TelemetryConfiguration:
 
     def configure(
         self,
-        config: Optional[
+        config: (
             dict[
                 TelemetryConfigurationType | str,
                 TelemetryMetricsConfiguration
@@ -986,8 +988,9 @@ class TelemetryConfiguration:
                 ]
                 | None,
             ]
-        ] = None,
-        clear: Optional[bool] = False,
+            | None
+        ) = None,
+        clear: bool = False,
     ) -> None:
         """
         Configure telemetry reporting.
@@ -1029,7 +1032,7 @@ class TelemetryConfiguration:
         self._valid = None
 
     def getConfigurations(
-        self, filter_enabled: Optional[bool] = True
+        self, filter_enabled: bool = True
     ) -> dict[TelemetryConfigurationType, TelemetryMetricsConfiguration | None]:
         """
         Returns a list of supported reporting contexts. If `filter_enabled` is `True`, only enabled contexts are returned.
@@ -1051,7 +1054,7 @@ class TelemetryConfiguration:
         return contexts
 
     def isEnabled(
-        self, configuration: Optional[TelemetryConfigurationType] = None
+        self, configuration: TelemetryConfigurationType | None = None
     ) -> bool:
         """
         Check if telemetry is enabled.
@@ -1071,7 +1074,7 @@ class TelemetryConfiguration:
 
         return False
 
-    def isValid(self, raise_exception: Optional[bool] = False) -> bool:
+    def isValid(self, raise_exception: bool = False) -> bool:
         """
         Validate the telemetry configuration.
 

--- a/openfga_sdk/telemetry/counters.py
+++ b/openfga_sdk/telemetry/counters.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Optional
+from typing import NamedTuple
 
 
 class TelemetryCounter(NamedTuple):
@@ -25,7 +25,7 @@ class TelemetryCounters:
 
     @staticmethod
     def get(
-        name: Optional[str] = None,
+        name: str | None = None,
     ) -> list[TelemetryCounter] | TelemetryCounter | None:
         if name is None:
             return TelemetryCounters._counters

--- a/openfga_sdk/telemetry/histograms.py
+++ b/openfga_sdk/telemetry/histograms.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Optional
+from typing import NamedTuple
 
 
 class TelemetryHistogram(NamedTuple):
@@ -24,7 +24,7 @@ class TelemetryHistograms:
 
     @staticmethod
     def get(
-        name: Optional[str] = None,
+        name: str | None = None,
     ) -> list[TelemetryHistogram] | TelemetryHistogram | None:
         if name is None:
             return TelemetryHistograms._histograms

--- a/openfga_sdk/telemetry/metrics.py
+++ b/openfga_sdk/telemetry/metrics.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from opentelemetry.metrics import Counter, Histogram, Meter, get_meter
 
 from openfga_sdk.telemetry.attributes import (
@@ -21,9 +19,9 @@ class TelemetryMetrics:
 
     def __init__(
         self,
-        meter: Optional[Meter] = None,
-        counters: Optional[dict[str, Counter]] = None,
-        histograms: Optional[dict[str, Histogram]] = None,
+        meter: Meter | None = None,
+        counters: dict[str, Counter] | None = None,
+        histograms: dict[str, Histogram] | None = None,
     ):
         self._meter = meter
         self._counters = counters or {}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This PR removes the `Optional` type hinter, as guidance for Python 3.10+ and [PEP 604's introduction](https://peps.python.org/pep-0604/) is to phase it out in favor of a simple `None` union type. Note that these are functionally identical and do not affect the method signature for existing integrations.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

- https://github.com/openfga/sdk-generator/pull/451

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
