### PR TITLE
Sync readme and client timeout changes

### DIFF
--- a/openfga_sdk/client/configuration.py
+++ b/openfga_sdk/client/configuration.py
@@ -30,6 +30,7 @@ class ClientConfiguration(Configuration):
         authorization_model_id=None,
         ssl_ca_cert=None,
         api_url=None,  # TODO: restructure when removing api_scheme/api_host
+        timeout_millisec: int | None = None,
     ):
         super().__init__(
             api_scheme,
@@ -39,6 +40,7 @@ class ClientConfiguration(Configuration):
             retry_params,
             ssl_ca_cert=ssl_ca_cert,
             api_url=api_url,
+            timeout_millisec=timeout_millisec,
         )
         self._authorization_model_id = authorization_model_id
 

--- a/openfga_sdk/rest.py
+++ b/openfga_sdk/rest.py
@@ -72,6 +72,7 @@ class RESTClientObject:
 
         self.proxy = configuration.proxy
         self.proxy_headers = configuration.proxy_headers
+        self._timeout_millisec = configuration.timeout_millisec
 
         # https pool manager
         self.pool_manager = aiohttp.ClientSession(connector=connector, trust_env=True)
@@ -117,7 +118,7 @@ class RESTClientObject:
 
         post_params = post_params or {}
         headers = headers or {}
-        timeout = _request_timeout or 5 * 60
+        timeout = _request_timeout or self._timeout_millisec / 1000
 
         if "Content-Type" not in headers:
             headers["Content-Type"] = "application/json"

--- a/openfga_sdk/sync/rest.py
+++ b/openfga_sdk/sync/rest.py
@@ -81,6 +81,8 @@ class RESTClientObject:
             else:
                 maxsize = 4
 
+        self._timeout_millisec = configuration.timeout_millisec
+
         # https pool manager
         if configuration.proxy:
             self.pool_manager = urllib3.ProxyManager(
@@ -148,7 +150,7 @@ class RESTClientObject:
         post_params = post_params or {}
         headers = headers or {}
 
-        timeout = None
+        timeout = urllib3.Timeout(total=self._timeout_millisec / 1000)
         if _request_timeout:
             if isinstance(_request_timeout, (float, int)):
                 timeout = urllib3.Timeout(total=_request_timeout)

--- a/test/api/open_fga_api_test.py
+++ b/test/api/open_fga_api_test.py
@@ -1148,6 +1148,17 @@ class TestOpenFgaApi(IsolatedAsyncioTestCase):
         self.assertEqual(configuration.api_url, "http://localhost:8080")
         configuration.is_valid()  # Should not throw and complain about scheme being invalid
 
+    def test_timeout_millisec(self):
+        """
+        Ensure that timeout_seconds is set and validated
+        """
+        configuration = openfga_sdk.Configuration(
+            api_url="http://localhost:8080",
+            timeout_millisec=10000,
+        )
+        self.assertEqual(configuration.timeout_millisec, 10000)
+        configuration.is_valid()
+
     async def test_bad_configuration_read_authorization_model(self):
         """
         Test whether FgaValidationException is raised for API (reading authorization models)

--- a/test/configuration_test.py
+++ b/test/configuration_test.py
@@ -136,6 +136,7 @@ class TestConfigurationSetDefaultAndGetDefaultCopy:
         }
         default_config.ssl_ca_cert = "/path/to/ca_cert.pem"
         default_config.api_url = "https://fga.example/api"
+        default_config.timeout_millisec = 10000
         Configuration.set_default(default_config)
 
         assert Configuration._default.api_scheme == "https"
@@ -183,6 +184,7 @@ class TestConfigurationSetDefaultAndGetDefaultCopy:
         }
         assert Configuration._default.ssl_ca_cert == "/path/to/ca_cert.pem"
         assert Configuration._default.api_url == "https://fga.example/api"
+        assert Configuration._default.timeout_millisec == 10000
 
     def test_configuration_get_default_copy(self, configuration):
         default_config = Configuration()
@@ -212,6 +214,7 @@ class TestConfigurationSetDefaultAndGetDefaultCopy:
         }
         default_config.ssl_ca_cert = "/path/to/ca_cert.pem"
         default_config.api_url = "https://fga.example/api"
+        default_config.timeout_millisec = 10000
         Configuration.set_default(default_config)
 
         copied_config = Configuration.get_default_copy()
@@ -229,6 +232,7 @@ class TestConfigurationSetDefaultAndGetDefaultCopy:
             assert copied_config.credentials._api_audience == "audience123"
             assert copied_config.credentials._api_issuer == "issuer123"
             assert copied_config.credentials._api_token == "token123"
+        assert Configuration._default.timeout_millisec == 10000
 
 
 class TestConfigurationValidityChecks:
@@ -361,6 +365,7 @@ class TestConfigurationMiscellaneous:
             },
             ssl_ca_cert="/path/to/ca_cert.pem",
             api_url="https://fga.example/api",
+            timeout_millisec=10000,
         )
 
         # Perform deep copy
@@ -394,3 +399,4 @@ class TestConfigurationMiscellaneous:
         )
         assert copied_config.ssl_ca_cert == config.ssl_ca_cert
         assert copied_config.api_url == config.api_url
+        assert copied_config.timeout_millisec == config.timeout_millisec

--- a/test/sync/open_fga_api_test.py
+++ b/test/sync/open_fga_api_test.py
@@ -1148,6 +1148,17 @@ class TestOpenFgaApiSync(IsolatedAsyncioTestCase):
         self.assertEqual(configuration.api_url, "http://localhost:8080")
         configuration.is_valid()  # Should not throw and complain about scheme being invalid
 
+    def test_timeout_millisec(self):
+        """
+        Ensure that timeout_millisec is set and validated
+        """
+        configuration = Configuration(
+            api_url="http://localhost:8080",
+            timeout_millisec=10000,
+        )
+        self.assertEqual(configuration.timeout_millisec, 10000)
+        configuration.is_valid()
+
     async def test_bad_configuration_read_authorization_model(self):
         """
         Test whether FgaValidationException is raised for API (reading authorization models)


### PR DESCRIPTION
## Description

Syncs the new client wide request timeout and docs changes across from the generator ahead of a release

## References

https://github.com/openfga/sdk-generator/pull/416
https://github.com/openfga/sdk-generator/pull/403

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
