### PR TITLE
docs: correct v0.9.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## v0.9.0
 
-### [0.9.0](https://github.com/openfga/python-sdk/compare/v0.8.1...v0.9.0) (2024-12-18)
+### [0.9.0](https://github.com/openfga/python-sdk/compare/v0.8.1...v0.9.0) (2024-12-19)
 
 - feat: remove client-side validation - thanks @GMorris-professional (#155)
 - feat: add support for `start_time` parameter in `ReadChanges` endpoint (#156) - Note, this feature requires v1.8.0 of OpenFGA or newer


### PR DESCRIPTION
## Description

We progressed forward in time since I wrote that entry

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

