### PR TITLE
fix: urllib3 compatibility < v2

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
+        urllib3-version: ["1.26.19", "2.2.2"]
 
     steps:
       - name: Checkout code
@@ -36,16 +37,18 @@ jobs:
             **/test-requirements*.txt
 
       - name: Install dependencies
-        run: pip install -r test-requirements.txt --upgrade pip
+        run: |
+          pip install -r test-requirements.txt --upgrade pip
+          pip install "urllib3==${{ matrix.urllib3-version }}"
 
-      - if: matrix.python-version == '3.10'
+      - if: matrix.python-version == '3.10' && matrix.urllib3-version == '1.26.19'
         name: Run `ruff`
         run: ruff check
 
       - name: Run tests and collect coverage
         run: pytest --cov-fail-under 60 --cov openfga_sdk
 
-      - if: matrix.python-version == '3.10'
+      - if: matrix.python-version == '3.10' && matrix.urllib3-version == '1.26.19'
         name: Upload coverage to Codecov
         uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         continue-on-error: true

--- a/openfga_sdk/sync/rest.py
+++ b/openfga_sdk/sync/rest.py
@@ -41,22 +41,22 @@ class RESTResponse(io.IOBase):
     Represents an HTTP response object in the synchronous client.
     """
 
-    _response: urllib3.BaseHTTPResponse
+    _response: urllib3.HTTPResponse
     _data: bytes
     _status: int
     _reason: str | None
 
     def __init__(
         self,
-        response: urllib3.BaseHTTPResponse,
+        response: urllib3.HTTPResponse,
         data: bytes,
         status: int | None = None,
         reason: str | None = None,
     ) -> None:
         """
-        Initializes a RESTResponse with a urllib3.BaseHTTPResponse and corresponding data.
+        Initializes a RESTResponse with a urllib3.HTTPResponse and corresponding data.
 
-        :param resp: The urllib3.BaseHTTPResponse object.
+        :param resp: The urllib3.HTTPResponse object.
         :param data: The raw byte data read from the response.
         """
         self._response = response
@@ -65,16 +65,16 @@ class RESTResponse(io.IOBase):
         self._reason = reason or response.reason
 
     @property
-    def response(self) -> urllib3.BaseHTTPResponse:
+    def response(self) -> urllib3.HTTPResponse:
         """
-        Returns the underlying urllib3.BaseHTTPResponse object.
+        Returns the underlying urllib3.HTTPResponse object.
         """
         return self._response
 
     @response.setter
-    def response(self, value: urllib3.BaseHTTPResponse) -> None:
+    def response(self, value: urllib3.HTTPResponse) -> None:
         """
-        Sets the underlying urllib3.BaseHTTPResponse object.
+        Sets the underlying urllib3.HTTPResponse object.
         """
         self._response = value
 
@@ -318,7 +318,7 @@ class RESTClientObject:
         return args
 
     def handle_response_exception(
-        self, response: RESTResponse | urllib3.BaseHTTPResponse
+        self, response: RESTResponse | urllib3.HTTPResponse
     ) -> None:
         """
         Raises exceptions if response status indicates an error.
@@ -462,7 +462,7 @@ class RESTClientObject:
         post_params: dict | None = None,
         _preload_content: bool = True,
         _request_timeout: float | tuple | None = None,
-    ) -> RESTResponse | urllib3.BaseHTTPResponse:
+    ) -> RESTResponse | urllib3.HTTPResponse:
         """
         Executes a request and returns the response object.
 
@@ -493,7 +493,7 @@ class RESTClientObject:
 
         # Send request, collect response handler
         wrapped_response: RESTResponse | None = None
-        raw_response: urllib3.BaseHTTPResponse = self.pool_manager.request(**args)
+        raw_response: urllib3.HTTPResponse = self.pool_manager.request(**args)
 
         # If we want to preload the response, read it
         if _preload_content:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ aiohttp >= 3.9.3, < 4
 python-dateutil >= 2.9.0, < 3
 setuptools >= 69.1.1
 build >= 1.2.1, < 2
-urllib3 >= 1.25.11, < 3
+urllib3 >= 1.26.19, >= 2.2.2, < 3
 opentelemetry-api >= 1.25.0, < 2


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

- Bumped dependency requirements for `urllib3` to specify >= v1.26.19 or >= v2.2.2
- Modified type hints in `RESTResponse` class to use `urllib3.HTTPResponse` instead of `urllib3.BaseHTTPResponse`
- Added matrix testing for different urllib3 versions in GitHub Actions workflow

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

