### PR TITLE
Fix issue where aiohttp.ClientResponse data wasn't being awaited on

### DIFF
--- a/openfga_sdk/rest.py
+++ b/openfga_sdk/rest.py
@@ -278,6 +278,9 @@ class RESTClientObject:
         if 200 <= response.status <= 299:
             return
 
+        if isinstance(response, aiohttp.ClientResponse):
+            response.data  = await response.read()
+
         match response.status:
             case 400:
                 raise ValidationException(http_resp=response)


### PR DESCRIPTION
Fixes issue #184 where aiohttp.ClientResponse data wasn't being awaited on. Credit to @extreme4all and @demetere for doing the actual investigation work here.

## Description

Added awaiting for the response data inside of the exception handler so that it is safe to read the response status.

## References

- Issue [184](https://github.com/openfga/python-sdk/issues/184)

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected

