### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -6,6 +6,8 @@ on:
 jobs:
   semgrep:
     name: Scan
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     container:
       image: returntocorp/semgrep


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/python-sdk/security/code-scanning/1](https://github.com/openfga/python-sdk/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the job definition for `semgrep` in `.github/workflows/semgrep.yaml`. The minimal required permission for this job is likely `contents: read`, since it only checks out code and runs a scan. You should insert the following block under the job name (`name: Scan`), before `runs-on: ubuntu-latest`. No additional imports or definitions are needed, as this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
