### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,6 +13,8 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/python-sdk/security/code-scanning/2](https://github.com/openfga/python-sdk/security/code-scanning/2)

To fix the problem, add a `permissions` block to the `test` job in `.github/workflows/main.yaml` to explicitly set the minimum required permissions. Since the job only needs to read repository contents (for checkout and running tests), set `contents: read`. This change should be made directly under the `test:` job definition (after `runs-on: ubuntu-latest`). No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
