### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -94,6 +94,8 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [publish]
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/python-sdk/security/code-scanning/3](https://github.com/openfga/python-sdk/security/code-scanning/3)

To fix the problem, add an explicit `permissions` block to the `create-release` job in `.github/workflows/main.yaml`. This block should grant only the minimal permissions required for the job to function. Since the job creates a GitHub release, it requires `contents: write` permission. The block should be added directly under the `create-release:` job definition, before the `steps:` key. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
