### PR TITLE
ci: fix flaky unit tests

### DIFF
--- a/test/api/open_fga_api_test.py
+++ b/test/api/open_fga_api_test.py
@@ -1526,14 +1526,14 @@ class TestOpenFgaApi(IsolatedAsyncioTestCase):
               "message": "Rate Limit exceeded"
             }
         """
-        retry_after_in_sec = 5
-        five_seconds_from_now = (
+        retry_after_in_sec = 10
+        ten_seconds_from_now = (
             datetime.now(timezone.utc) + timedelta(seconds=retry_after_in_sec)
         ).strftime("%a, %d %b %Y %H:%M:%S GMT")
         mock_http_response = http_mock_response(
             body=error_response_body,
             status=429,
-            headers={"Retry-After": five_seconds_from_now},
+            headers={"Retry-After": ten_seconds_from_now},
         )
         mock_request.side_effect = [
             RateLimitExceededError(http_resp=mock_http_response),
@@ -1541,7 +1541,7 @@ class TestOpenFgaApi(IsolatedAsyncioTestCase):
         ]
 
         retry = openfga_sdk.configuration.RetryParams(
-            max_retry=1, min_wait_in_ms=10, max_wait_in_sec=1
+            max_retry=1, min_wait_in_ms=10, max_wait_in_sec=15
         )
         configuration = self.configuration
         configuration.store_id = store_id
@@ -1563,7 +1563,7 @@ class TestOpenFgaApi(IsolatedAsyncioTestCase):
             mock_request.assert_called()
             self.assertEqual(mock_request.call_count, 2)
             self.assertTrue(
-                retry_after_in_sec - 1
+                retry_after_in_sec - 2
                 <= mock_sleep.call_args[0][0]
                 <= retry_after_in_sec
             )

--- a/test/client/client_test.py
+++ b/test/client/client_test.py
@@ -2041,12 +2041,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
         Check whether a user is authorized to access an object
         """
 
-        # First, mock the response
-        mock_request.side_effect = [
-            mock_response('{"allowed": true, "resolution": "1234"}', 200),
-            mock_response('{"allowed": false, "resolution": "1234"}', 200),
-            mock_response('{"allowed": true, "resolution": "1234"}', 200),
-        ]
         body1 = ClientCheckRequest(
             object="document:2021-budget",
             relation="reader",
@@ -2062,6 +2056,20 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             relation="reader",
             user="user:81684243-9356-4421-8fbf-a4f8d36aa31d",
         )
+
+        # Mock the response based on request body to avoid race conditions
+        def mock_side_effect(*args, **kwargs):
+            body = kwargs.get("body", {})
+            user = body.get("tuple_key", {}).get("user", "")
+            if user == "user:81684243-9356-4421-8fbf-a4f8d36aa31b":
+                return mock_response('{"allowed": true, "resolution": "1234"}', 200)
+            elif user == "user:81684243-9356-4421-8fbf-a4f8d36aa31c":
+                return mock_response('{"allowed": false, "resolution": "1234"}', 200)
+            elif user == "user:81684243-9356-4421-8fbf-a4f8d36aa31d":
+                return mock_response('{"allowed": true, "resolution": "1234"}', 200)
+            return mock_response('{"allowed": false, "resolution": "1234"}', 200)
+
+        mock_request.side_effect = mock_side_effect
         configuration = self.configuration
         configuration.store_id = store_id
         async with OpenFgaClient(configuration) as api_client:
@@ -2150,12 +2158,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
 }
         """
 
-        # First, mock the response
-        mock_request.side_effect = [
-            mock_response('{"allowed": true, "resolution": "1234"}', 200),
-            ValidationException(http_resp=http_mock_response(response_body, 400)),
-            mock_response('{"allowed": false, "resolution": "1234"}', 200),
-        ]
         body1 = ClientCheckRequest(
             object="document:2021-budget",
             relation="reader",
@@ -2171,6 +2173,22 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             relation="reader",
             user="user:81684243-9356-4421-8fbf-a4f8d36aa31d",
         )
+
+        # Mock the response based on request body to avoid race conditions
+        def mock_side_effect(*args, **kwargs):
+            body = kwargs.get("body", {})
+            user = body.get("tuple_key", {}).get("user", "")
+            if user == "user:81684243-9356-4421-8fbf-a4f8d36aa31b":
+                return mock_response('{"allowed": true, "resolution": "1234"}', 200)
+            elif user == "user:81684243-9356-4421-8fbf-a4f8d36aa31c":
+                raise ValidationException(
+                    http_resp=http_mock_response(response_body, 400)
+                )
+            elif user == "user:81684243-9356-4421-8fbf-a4f8d36aa31d":
+                return mock_response('{"allowed": false, "resolution": "1234"}', 200)
+            return mock_response('{"allowed": false, "resolution": "1234"}', 200)
+
+        mock_request.side_effect = mock_side_effect
         configuration = self.configuration
         configuration.store_id = store_id
         async with OpenFgaClient(configuration) as api_client:


### PR DESCRIPTION
This PR addresses flaky unit tests resulting from race conditions in async batch check operations and timing precision issues in retry logic.

- **Fixed race conditions when running BatchCheck tests with parallelization**
  Replaced sequential mock responses with conditional responses based on request body content. I only noticed this after the package modernization and adoption of `uv`, where `pytest` is run with parallelization enabled by default, unlike previously.

- **Improved retry timing stability**
  I adjusted the retry delay from exact matches to tolerance ranges of 1 or 2 seconds, and increased test timeouts to account for variance. I haven't encountered this locally, but have seen it pop up a few times on our CI during PR status checks.

## References

https://github.com/openfga/sdk-generator/pull/629

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Stabilized batch check tests by making mock responses depend on request content, reducing flakiness with concurrent requests and accurately simulating per-request successes and failures.
  * Updated rate-limit retry tests to use longer Retry-After intervals and more tolerant timing assertions to align with current retry behavior.
  * Applied improvements across both async and sync client test suites.
  * No changes to public APIs or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->