### PR TITLE
chore(deps): bump minimum versions for aiohttp, python-dotenv, and Py…

### DIFF
--- a/example/example1/requirements.txt
+++ b/example/example1/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp >= 3.12.15, < 4
+aiohttp >= 3.13.4, < 4
 aiosignal >= 1.4.0
 attrs >= 25.3.0
 frozenlist >= 1.7.0
@@ -8,4 +8,4 @@ openfga-sdk >= 0.10.2  # x-release-please-version
 python-dateutil >= 2.9.0.post0
 urllib3 >= 1.26.19, != 2.0.*, != 2.1.*, != 2.2.0, != 2.2.1, < 3
 yarl >= 1.20.1
-python-dotenv >= 1, <2
+python-dotenv >= 1.2.2, <2

--- a/example/opentelemetry/requirements.txt
+++ b/example/opentelemetry/requirements.txt
@@ -1,3 +1,3 @@
-python-dotenv >= 1, <2
+python-dotenv >= 1.2.2, <2
 opentelemetry-sdk >= 1, <2
 opentelemetry-exporter-otlp-proto-grpc >= 1.25, <2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ keywords=[
 requires-python=">=3.10"
 license="Apache-2.0"
 dependencies = [
-    "aiohttp>=3.9.3",
+    "aiohttp>=3.13.4",
     "python-dateutil>=2.9.0",
     "opentelemetry-api>=1.25.0",
     "urllib3>=1.26.19,<3"


### PR DESCRIPTION
 Raises the minimum allowed versions to exclude known vulnerable releases:
  - aiohttp: >=3.9.3 -> >=3.13.4 (fixes 18 CVEs across HTTP parsing, DoS, and header injection)
  - python-dotenv: >=1 -> >=1.2.2 (CVE-2026-28684, symlink following)
  - Pygments: uv.lock updated to >=2.20.0 (CVE-2026-4539, ReDoS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to ensure improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->