### PR TITLE
fix: add token expiry buffer to prevent expired token usage and lock concurrent refreshes

### DIFF
--- a/openfga_sdk/oauth2.py
+++ b/openfga_sdk/oauth2.py
@@ -41,6 +41,7 @@ class OAuth2Client:
         self._access_token = None
         self._access_expiry_time = None
         self._access_token_expiry_buffer = 0
+        self._lock = asyncio.Lock()
         self._telemetry = Telemetry()
 
         if configuration is None:
@@ -80,7 +81,9 @@ class OAuth2Client:
         # Add scope parameter if scopes are configured
         if configuration.scopes is not None:
             if isinstance(configuration.scopes, list):
-                scope_str = " ".join(s.strip() for s in configuration.scopes if s and s.strip())
+                scope_str = " ".join(
+                    s.strip() for s in configuration.scopes if s and s.strip()
+                )
             else:
                 scope_str = (
                     configuration.scopes.strip()
@@ -162,8 +165,8 @@ class OAuth2Client:
         """
         If configured, return the header for authentication
         """
-        # check to see token is valid
         if not self._token_valid():
-            # In this case, the token is not valid, we need to get the refresh the token
-            await self._obtain_token(client)
+            async with self._lock:
+                if not self._token_valid():
+                    await self._obtain_token(client)
         return {"Authorization": f"Bearer {self._access_token}"}

--- a/openfga_sdk/oauth2.py
+++ b/openfga_sdk/oauth2.py
@@ -152,9 +152,8 @@ class OAuth2Client:
                 if api_response.get("expires_in") and api_response.get("access_token"):
                     self._token_state = _TokenState(
                         access_token=api_response.get("access_token"),
-                        expiry_time=datetime.now() + timedelta(
-                            seconds=int(api_response.get("expires_in"))
-                        ),
+                        expiry_time=datetime.now()
+                        + timedelta(seconds=int(api_response.get("expires_in"))),
                         expiry_buffer=(
                             TOKEN_EXPIRY_THRESHOLD_BUFFER_IN_SEC
                             + random.random() * TOKEN_EXPIRY_JITTER_IN_SEC

--- a/openfga_sdk/oauth2.py
+++ b/openfga_sdk/oauth2.py
@@ -4,6 +4,7 @@ import math
 import random
 import sys
 
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 import urllib3
@@ -18,6 +19,13 @@ from openfga_sdk.credentials import Credentials
 from openfga_sdk.exceptions import AuthenticationError
 from openfga_sdk.telemetry.attributes import TelemetryAttributes
 from openfga_sdk.telemetry.telemetry import Telemetry
+
+
+@dataclass(frozen=True)
+class _TokenState:
+    access_token: str
+    expiry_time: datetime
+    expiry_buffer: float
 
 
 def jitter(loop_count, min_wait_in_ms):
@@ -38,9 +46,7 @@ def jitter(loop_count, min_wait_in_ms):
 class OAuth2Client:
     def __init__(self, credentials: Credentials, configuration=None):
         self._credentials = credentials
-        self._access_token = None
-        self._access_expiry_time = None
-        self._access_token_expiry_buffer = 0
+        self._token_state: _TokenState | None = None
         self._lock = asyncio.Lock()
         self._telemetry = Telemetry()
 
@@ -53,10 +59,11 @@ class OAuth2Client:
         """
         Return whether token is valid (with proactive expiry buffer to avoid using near-expired tokens)
         """
-        if self._access_token is None or self._access_expiry_time is None:
+        state = self._token_state  # atomic snapshot — either old or new, never torn
+        if state is None:
             return False
-        remaining = (self._access_expiry_time - datetime.now()).total_seconds()
-        return remaining > self._access_token_expiry_buffer
+        remaining = (state.expiry_time - datetime.now()).total_seconds()
+        return remaining > state.expiry_buffer
 
     async def _obtain_token(self, client):
         """
@@ -143,13 +150,15 @@ class OAuth2Client:
                     raise AuthenticationError(http_resp=raw_response)
 
                 if api_response.get("expires_in") and api_response.get("access_token"):
-                    self._access_expiry_time = datetime.now() + timedelta(
-                        seconds=int(api_response.get("expires_in"))
-                    )
-                    self._access_token = api_response.get("access_token")
-                    self._access_token_expiry_buffer = (
-                        TOKEN_EXPIRY_THRESHOLD_BUFFER_IN_SEC
-                        + random.random() * TOKEN_EXPIRY_JITTER_IN_SEC
+                    self._token_state = _TokenState(
+                        access_token=api_response.get("access_token"),
+                        expiry_time=datetime.now() + timedelta(
+                            seconds=int(api_response.get("expires_in"))
+                        ),
+                        expiry_buffer=(
+                            TOKEN_EXPIRY_THRESHOLD_BUFFER_IN_SEC
+                            + random.random() * TOKEN_EXPIRY_JITTER_IN_SEC
+                        ),
                     )
                     self._telemetry.metrics.credentialsRequest(
                         attributes={
@@ -169,4 +178,4 @@ class OAuth2Client:
             async with self._lock:
                 if not self._token_valid():
                     await self._obtain_token(client)
-        return {"Authorization": f"Bearer {self._access_token}"}
+        return {"Authorization": f"Bearer {self._token_state.access_token}"}

--- a/openfga_sdk/oauth2.py
+++ b/openfga_sdk/oauth2.py
@@ -9,7 +9,11 @@ from datetime import datetime, timedelta
 import urllib3
 
 from openfga_sdk.configuration import Configuration
-from openfga_sdk.constants import USER_AGENT
+from openfga_sdk.constants import (
+    TOKEN_EXPIRY_JITTER_IN_SEC,
+    TOKEN_EXPIRY_THRESHOLD_BUFFER_IN_SEC,
+    USER_AGENT,
+)
 from openfga_sdk.credentials import Credentials
 from openfga_sdk.exceptions import AuthenticationError
 from openfga_sdk.telemetry.attributes import TelemetryAttributes
@@ -36,6 +40,7 @@ class OAuth2Client:
         self._credentials = credentials
         self._access_token = None
         self._access_expiry_time = None
+        self._access_token_expiry_buffer = 0
         self._telemetry = Telemetry()
 
         if configuration is None:
@@ -45,13 +50,12 @@ class OAuth2Client:
 
     def _token_valid(self):
         """
-        Return whether token is valid
+        Return whether token is valid (with proactive expiry buffer to avoid using near-expired tokens)
         """
         if self._access_token is None or self._access_expiry_time is None:
             return False
-        if self._access_expiry_time < datetime.now():
-            return False
-        return True
+        remaining = (self._access_expiry_time - datetime.now()).total_seconds()
+        return remaining > self._access_token_expiry_buffer
 
     async def _obtain_token(self, client):
         """
@@ -140,6 +144,10 @@ class OAuth2Client:
                         seconds=int(api_response.get("expires_in"))
                     )
                     self._access_token = api_response.get("access_token")
+                    self._access_token_expiry_buffer = (
+                        TOKEN_EXPIRY_THRESHOLD_BUFFER_IN_SEC
+                        + random.random() * TOKEN_EXPIRY_JITTER_IN_SEC
+                    )
                     self._telemetry.metrics.credentialsRequest(
                         attributes={
                             TelemetryAttributes.fga_client_request_client_id: configuration.client_id

--- a/openfga_sdk/oauth2.py
+++ b/openfga_sdk/oauth2.py
@@ -1,10 +1,7 @@
 import asyncio
 import json
-import math
 import random
-import sys
 
-from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 import urllib3
@@ -17,30 +14,9 @@ from openfga_sdk.constants import (
 )
 from openfga_sdk.credentials import Credentials
 from openfga_sdk.exceptions import AuthenticationError
+from openfga_sdk.oauth2_common import _TokenState, jitter
 from openfga_sdk.telemetry.attributes import TelemetryAttributes
 from openfga_sdk.telemetry.telemetry import Telemetry
-
-
-@dataclass(frozen=True)
-class _TokenState:
-    access_token: str
-    expiry_time: datetime
-    expiry_buffer: float
-
-
-def jitter(loop_count, min_wait_in_ms):
-    """
-    Generate a random jitter value for exponential backoff
-    """
-    minimum = math.ceil(2**loop_count * min_wait_in_ms)
-    maximum = math.ceil(2 ** (loop_count + 1) * min_wait_in_ms)
-    jitter = random.randrange(minimum, maximum) / 1000
-
-    # If running in pytest, set jitter to 0 to speed up tests
-    if "pytest" in sys.modules:
-        jitter = 0
-
-    return jitter
 
 
 class OAuth2Client:

--- a/openfga_sdk/oauth2_common.py
+++ b/openfga_sdk/oauth2_common.py
@@ -1,0 +1,28 @@
+import math
+import random
+import sys
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class _TokenState:
+    access_token: str
+    expiry_time: datetime
+    expiry_buffer: float
+
+
+def jitter(loop_count, min_wait_in_ms):
+    """
+    Generate a random jitter value for exponential backoff
+    """
+    minimum = math.ceil(2**loop_count * min_wait_in_ms)
+    maximum = math.ceil(2 ** (loop_count + 1) * min_wait_in_ms)
+    jitter = random.randrange(minimum, maximum) / 1000
+
+    # If running in pytest, set jitter to 0 to speed up tests
+    if "pytest" in sys.modules:
+        jitter = 0
+
+    return jitter

--- a/openfga_sdk/sync/oauth2.py
+++ b/openfga_sdk/sync/oauth2.py
@@ -153,9 +153,8 @@ class OAuth2Client:
                 if api_response.get("expires_in") and api_response.get("access_token"):
                     self._token_state = _TokenState(
                         access_token=api_response.get("access_token"),
-                        expiry_time=datetime.now() + timedelta(
-                            seconds=int(api_response.get("expires_in"))
-                        ),
+                        expiry_time=datetime.now()
+                        + timedelta(seconds=int(api_response.get("expires_in"))),
                         expiry_buffer=(
                             TOKEN_EXPIRY_THRESHOLD_BUFFER_IN_SEC
                             + random.random() * TOKEN_EXPIRY_JITTER_IN_SEC

--- a/openfga_sdk/sync/oauth2.py
+++ b/openfga_sdk/sync/oauth2.py
@@ -2,6 +2,7 @@ import json
 import math
 import random
 import sys
+import threading
 import time
 
 from datetime import datetime, timedelta
@@ -41,6 +42,7 @@ class OAuth2Client:
         self._access_token = None
         self._access_expiry_time = None
         self._access_token_expiry_buffer = 0
+        self._lock = threading.Lock()
         self._telemetry = Telemetry()
 
         if configuration is None:
@@ -80,7 +82,9 @@ class OAuth2Client:
         # Add scope parameter if scopes are configured
         if configuration.scopes is not None:
             if isinstance(configuration.scopes, list):
-                scope_str = " ".join(s.strip() for s in configuration.scopes if s and s.strip())
+                scope_str = " ".join(
+                    s.strip() for s in configuration.scopes if s and s.strip()
+                )
             else:
                 scope_str = (
                     configuration.scopes.strip()
@@ -162,8 +166,8 @@ class OAuth2Client:
         """
         If configured, return the header for authentication
         """
-        # check to see token is valid
         if not self._token_valid():
-            # In this case, the token is not valid, we need to get the refresh the token
-            self._obtain_token(client)
+            with self._lock:
+                if not self._token_valid():
+                    self._obtain_token(client)
         return {"Authorization": f"Bearer {self._access_token}"}

--- a/openfga_sdk/sync/oauth2.py
+++ b/openfga_sdk/sync/oauth2.py
@@ -1,11 +1,8 @@
 import json
-import math
 import random
-import sys
 import threading
 import time
 
-from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 import urllib3
@@ -18,30 +15,9 @@ from openfga_sdk.constants import (
 )
 from openfga_sdk.credentials import Credentials
 from openfga_sdk.exceptions import AuthenticationError
+from openfga_sdk.oauth2_common import _TokenState, jitter
 from openfga_sdk.telemetry.attributes import TelemetryAttributes
 from openfga_sdk.telemetry.telemetry import Telemetry
-
-
-@dataclass(frozen=True)
-class _TokenState:
-    access_token: str
-    expiry_time: datetime
-    expiry_buffer: float
-
-
-def jitter(loop_count, min_wait_in_ms):
-    """
-    Generate a random jitter value for exponential backoff
-    """
-    minimum = math.ceil(2**loop_count * min_wait_in_ms)
-    maximum = math.ceil(2 ** (loop_count + 1) * min_wait_in_ms)
-    jitter = random.randrange(minimum, maximum) / 1000
-
-    # If running in pytest, set jitter to 0 to speed up tests
-    if "pytest" in sys.modules:
-        jitter = 0
-
-    return jitter
 
 
 class OAuth2Client:

--- a/openfga_sdk/sync/oauth2.py
+++ b/openfga_sdk/sync/oauth2.py
@@ -5,6 +5,7 @@ import sys
 import threading
 import time
 
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 import urllib3
@@ -19,6 +20,13 @@ from openfga_sdk.credentials import Credentials
 from openfga_sdk.exceptions import AuthenticationError
 from openfga_sdk.telemetry.attributes import TelemetryAttributes
 from openfga_sdk.telemetry.telemetry import Telemetry
+
+
+@dataclass(frozen=True)
+class _TokenState:
+    access_token: str
+    expiry_time: datetime
+    expiry_buffer: float
 
 
 def jitter(loop_count, min_wait_in_ms):
@@ -39,9 +47,7 @@ def jitter(loop_count, min_wait_in_ms):
 class OAuth2Client:
     def __init__(self, credentials: Credentials, configuration=None):
         self._credentials = credentials
-        self._access_token = None
-        self._access_expiry_time = None
-        self._access_token_expiry_buffer = 0
+        self._token_state: _TokenState | None = None
         self._lock = threading.Lock()
         self._telemetry = Telemetry()
 
@@ -54,10 +60,11 @@ class OAuth2Client:
         """
         Return whether token is valid (with proactive expiry buffer to avoid using near-expired tokens)
         """
-        if self._access_token is None or self._access_expiry_time is None:
+        state = self._token_state  # atomic snapshot — either old or new, never torn
+        if state is None:
             return False
-        remaining = (self._access_expiry_time - datetime.now()).total_seconds()
-        return remaining > self._access_token_expiry_buffer
+        remaining = (state.expiry_time - datetime.now()).total_seconds()
+        return remaining > state.expiry_buffer
 
     def _obtain_token(self, client):
         """
@@ -144,13 +151,15 @@ class OAuth2Client:
                     raise AuthenticationError(http_resp=raw_response)
 
                 if api_response.get("expires_in") and api_response.get("access_token"):
-                    self._access_expiry_time = datetime.now() + timedelta(
-                        seconds=int(api_response.get("expires_in"))
-                    )
-                    self._access_token = api_response.get("access_token")
-                    self._access_token_expiry_buffer = (
-                        TOKEN_EXPIRY_THRESHOLD_BUFFER_IN_SEC
-                        + random.random() * TOKEN_EXPIRY_JITTER_IN_SEC
+                    self._token_state = _TokenState(
+                        access_token=api_response.get("access_token"),
+                        expiry_time=datetime.now() + timedelta(
+                            seconds=int(api_response.get("expires_in"))
+                        ),
+                        expiry_buffer=(
+                            TOKEN_EXPIRY_THRESHOLD_BUFFER_IN_SEC
+                            + random.random() * TOKEN_EXPIRY_JITTER_IN_SEC
+                        ),
                     )
                     self._telemetry.metrics.credentialsRequest(
                         attributes={
@@ -170,4 +179,4 @@ class OAuth2Client:
             with self._lock:
                 if not self._token_valid():
                     self._obtain_token(client)
-        return {"Authorization": f"Bearer {self._access_token}"}
+        return {"Authorization": f"Bearer {self._token_state.access_token}"}

--- a/openfga_sdk/sync/oauth2.py
+++ b/openfga_sdk/sync/oauth2.py
@@ -9,7 +9,11 @@ from datetime import datetime, timedelta
 import urllib3
 
 from openfga_sdk.configuration import Configuration
-from openfga_sdk.constants import USER_AGENT
+from openfga_sdk.constants import (
+    TOKEN_EXPIRY_JITTER_IN_SEC,
+    TOKEN_EXPIRY_THRESHOLD_BUFFER_IN_SEC,
+    USER_AGENT,
+)
 from openfga_sdk.credentials import Credentials
 from openfga_sdk.exceptions import AuthenticationError
 from openfga_sdk.telemetry.attributes import TelemetryAttributes
@@ -36,6 +40,7 @@ class OAuth2Client:
         self._credentials = credentials
         self._access_token = None
         self._access_expiry_time = None
+        self._access_token_expiry_buffer = 0
         self._telemetry = Telemetry()
 
         if configuration is None:
@@ -45,13 +50,12 @@ class OAuth2Client:
 
     def _token_valid(self):
         """
-        Return whether token is valid
+        Return whether token is valid (with proactive expiry buffer to avoid using near-expired tokens)
         """
         if self._access_token is None or self._access_expiry_time is None:
             return False
-        if self._access_expiry_time < datetime.now():
-            return False
-        return True
+        remaining = (self._access_expiry_time - datetime.now()).total_seconds()
+        return remaining > self._access_token_expiry_buffer
 
     def _obtain_token(self, client):
         """
@@ -140,6 +144,10 @@ class OAuth2Client:
                         seconds=int(api_response.get("expires_in"))
                     )
                     self._access_token = api_response.get("access_token")
+                    self._access_token_expiry_buffer = (
+                        TOKEN_EXPIRY_THRESHOLD_BUFFER_IN_SEC
+                        + random.random() * TOKEN_EXPIRY_JITTER_IN_SEC
+                    )
                     self._telemetry.metrics.credentialsRequest(
                         attributes={
                             TelemetryAttributes.fga_client_request_client_id: configuration.client_id

--- a/test/oauth2_test.py
+++ b/test/oauth2_test.py
@@ -11,7 +11,8 @@ from openfga_sdk.configuration import Configuration
 from openfga_sdk.constants import TOKEN_EXPIRY_THRESHOLD_BUFFER_IN_SEC, USER_AGENT
 from openfga_sdk.credentials import CredentialConfiguration, Credentials
 from openfga_sdk.exceptions import AuthenticationError
-from openfga_sdk.oauth2 import OAuth2Client, _TokenState
+from openfga_sdk.oauth2 import OAuth2Client
+from openfga_sdk.oauth2_common import _TokenState
 
 
 # Helper function to construct mock response

--- a/test/oauth2_test.py
+++ b/test/oauth2_test.py
@@ -1,4 +1,5 @@
 import asyncio
+
 from datetime import datetime, timedelta
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch

--- a/test/oauth2_test.py
+++ b/test/oauth2_test.py
@@ -6,7 +6,7 @@ import urllib3
 
 from openfga_sdk import rest
 from openfga_sdk.configuration import Configuration
-from openfga_sdk.constants import USER_AGENT
+from openfga_sdk.constants import TOKEN_EXPIRY_THRESHOLD_BUFFER_IN_SEC, USER_AGENT
 from openfga_sdk.credentials import CredentialConfiguration, Credentials
 from openfga_sdk.exceptions import AuthenticationError
 from openfga_sdk.oauth2 import OAuth2Client
@@ -34,7 +34,7 @@ class TestOAuth2Client(IsolatedAsyncioTestCase):
         """
         client = OAuth2Client(None)
         client._access_token = "XYZ123"
-        client._access_expiry_time = datetime.now() + timedelta(seconds=60)
+        client._access_expiry_time = datetime.now() + timedelta(seconds=3600)
         auth_header = await client.get_authentication_header(None)
         self.assertEqual(auth_header, {"Authorization": "Bearer XYZ123"})
 
@@ -649,6 +649,49 @@ This is not a JSON response
                 "grant_type": "client_credentials",
             },
         )
+        await rest_client.close()
+
+    @patch.object(rest.RESTClientObject, "request")
+    @patch("openfga_sdk.oauth2.random")
+    async def test_get_authentication_refreshes_near_expiry_token(
+        self, mock_random, mock_request
+    ):
+        """
+        Token close to expiry (within buffer window) should trigger a proactive refresh
+        """
+        mock_random.random.return_value = 0
+        short_lived_secs = max(1, TOKEN_EXPIRY_THRESHOLD_BUFFER_IN_SEC - 1)
+
+        mock_request.side_effect = [
+            mock_response(
+                f'{{"expires_in": {short_lived_secs}, "access_token": "short-lived-token"}}',
+                200,
+            ),
+            mock_response(
+                '{"expires_in": 3600, "access_token": "refreshed-token"}',
+                200,
+            ),
+        ]
+
+        credentials = Credentials(
+            method="client_credentials",
+            configuration=CredentialConfiguration(
+                client_id="myclientid",
+                client_secret="mysecret",
+                api_issuer="issuer.fga.example",
+                api_audience="myaudience",
+            ),
+        )
+        rest_client = rest.RESTClientObject(Configuration())
+        client = OAuth2Client(credentials)
+
+        header1 = await client.get_authentication_header(rest_client)
+        header2 = await client.get_authentication_header(rest_client)
+
+        self.assertEqual(header1, {"Authorization": "Bearer short-lived-token"})
+        self.assertEqual(header2, {"Authorization": "Bearer refreshed-token"})
+        self.assertEqual(mock_request.call_count, 2)
+
         await rest_client.close()
 
     @patch.object(rest.RESTClientObject, "request")

--- a/test/oauth2_test.py
+++ b/test/oauth2_test.py
@@ -11,7 +11,7 @@ from openfga_sdk.configuration import Configuration
 from openfga_sdk.constants import TOKEN_EXPIRY_THRESHOLD_BUFFER_IN_SEC, USER_AGENT
 from openfga_sdk.credentials import CredentialConfiguration, Credentials
 from openfga_sdk.exceptions import AuthenticationError
-from openfga_sdk.oauth2 import OAuth2Client
+from openfga_sdk.oauth2 import OAuth2Client, _TokenState
 
 
 # Helper function to construct mock response
@@ -35,8 +35,11 @@ class TestOAuth2Client(IsolatedAsyncioTestCase):
         Test getting authentication header when method is client credentials
         """
         client = OAuth2Client(None)
-        client._access_token = "XYZ123"
-        client._access_expiry_time = datetime.now() + timedelta(seconds=3600)
+        client._token_state = _TokenState(
+            access_token="XYZ123",
+            expiry_time=datetime.now() + timedelta(seconds=3600),
+            expiry_buffer=0,
+        )
         auth_header = await client.get_authentication_header(None)
         self.assertEqual(auth_header, {"Authorization": "Bearer XYZ123"})
 
@@ -67,9 +70,9 @@ class TestOAuth2Client(IsolatedAsyncioTestCase):
         client = OAuth2Client(credentials)
         auth_header = await client.get_authentication_header(rest_client)
         self.assertEqual(auth_header, {"Authorization": "Bearer AABBCCDD"})
-        self.assertEqual(client._access_token, "AABBCCDD")
+        self.assertEqual(client._token_state.access_token, "AABBCCDD")
         self.assertGreaterEqual(
-            client._access_expiry_time, current_time + timedelta(seconds=120)
+            client._token_state.expiry_time, current_time + timedelta(seconds=120)
         )
         expected_header = urllib3.response.HTTPHeaderDict(
             {
@@ -151,8 +154,11 @@ class TestOAuth2Client(IsolatedAsyncioTestCase):
         rest_client = rest.RESTClientObject(Configuration())
         client = OAuth2Client(credentials)
 
-        client._access_token = "XYZ123"
-        client._access_expiry_time = datetime.now() - timedelta(seconds=240)
+        client._token_state = _TokenState(
+            access_token="XYZ123",
+            expiry_time=datetime.now() - timedelta(seconds=240),
+            expiry_buffer=0,
+        )
 
         with self.assertRaises(AuthenticationError):
             await client.get_authentication_header(rest_client)
@@ -293,9 +299,9 @@ This is not a JSON response
         client = OAuth2Client(credentials)
         auth_header = await client.get_authentication_header(rest_client)
         self.assertEqual(auth_header, {"Authorization": "Bearer AABBCCDD"})
-        self.assertEqual(client._access_token, "AABBCCDD")
+        self.assertEqual(client._token_state.access_token, "AABBCCDD")
         self.assertGreaterEqual(
-            client._access_expiry_time, current_time + timedelta(seconds=120)
+            client._token_state.expiry_time, current_time + timedelta(seconds=120)
         )
         expected_header = urllib3.response.HTTPHeaderDict(
             {
@@ -348,9 +354,9 @@ This is not a JSON response
         client = OAuth2Client(credentials)
         auth_header = await client.get_authentication_header(rest_client)
         self.assertEqual(auth_header, {"Authorization": "Bearer AABBCCDD"})
-        self.assertEqual(client._access_token, "AABBCCDD")
+        self.assertEqual(client._token_state.access_token, "AABBCCDD")
         self.assertGreaterEqual(
-            client._access_expiry_time, current_time + timedelta(seconds=120)
+            client._token_state.expiry_time, current_time + timedelta(seconds=120)
         )
         expected_header = urllib3.response.HTTPHeaderDict(
             {
@@ -403,9 +409,9 @@ This is not a JSON response
         client = OAuth2Client(credentials)
         auth_header = await client.get_authentication_header(rest_client)
         self.assertEqual(auth_header, {"Authorization": "Bearer AABBCCDD"})
-        self.assertEqual(client._access_token, "AABBCCDD")
+        self.assertEqual(client._token_state.access_token, "AABBCCDD")
         self.assertGreaterEqual(
-            client._access_expiry_time, current_time + timedelta(seconds=120)
+            client._token_state.expiry_time, current_time + timedelta(seconds=120)
         )
         expected_header = urllib3.response.HTTPHeaderDict(
             {
@@ -458,9 +464,9 @@ This is not a JSON response
         client = OAuth2Client(credentials)
         auth_header = await client.get_authentication_header(rest_client)
         self.assertEqual(auth_header, {"Authorization": "Bearer AABBCCDD"})
-        self.assertEqual(client._access_token, "AABBCCDD")
+        self.assertEqual(client._token_state.access_token, "AABBCCDD")
         self.assertGreaterEqual(
-            client._access_expiry_time, current_time + timedelta(seconds=120)
+            client._token_state.expiry_time, current_time + timedelta(seconds=120)
         )
         expected_header = urllib3.response.HTTPHeaderDict(
             {
@@ -516,9 +522,9 @@ This is not a JSON response
         client = OAuth2Client(credentials)
         auth_header = await client.get_authentication_header(rest_client)
         self.assertEqual(auth_header, {"Authorization": "Bearer AABBCCDD"})
-        self.assertEqual(client._access_token, "AABBCCDD")
+        self.assertEqual(client._token_state.access_token, "AABBCCDD")
         self.assertGreaterEqual(
-            client._access_expiry_time, current_time + timedelta(seconds=120)
+            client._token_state.expiry_time, current_time + timedelta(seconds=120)
         )
         expected_header = urllib3.response.HTTPHeaderDict(
             {
@@ -575,9 +581,9 @@ This is not a JSON response
         client = OAuth2Client(credentials)
         auth_header = await client.get_authentication_header(rest_client)
         self.assertEqual(auth_header, {"Authorization": "Bearer AABBCCDD"})
-        self.assertEqual(client._access_token, "AABBCCDD")
+        self.assertEqual(client._token_state.access_token, "AABBCCDD")
         self.assertGreaterEqual(
-            client._access_expiry_time, current_time + timedelta(seconds=120)
+            client._token_state.expiry_time, current_time + timedelta(seconds=120)
         )
         expected_header = urllib3.response.HTTPHeaderDict(
             {
@@ -718,9 +724,11 @@ This is not a JSON response
         async def mock_obtain_token(client):
             obtain_calls.append(1)
             await asyncio.sleep(0)  # yield so other coroutines reach the lock
-            oauth_client._access_token = "concurrent-token"
-            oauth_client._access_expiry_time = datetime.now() + timedelta(seconds=3600)
-            oauth_client._access_token_expiry_buffer = 300
+            oauth_client._token_state = _TokenState(
+                access_token="concurrent-token",
+                expiry_time=datetime.now() + timedelta(seconds=3600),
+                expiry_buffer=300,
+            )
 
         with patch.object(oauth_client, "_obtain_token", side_effect=mock_obtain_token):
             results = await asyncio.gather(

--- a/test/oauth2_test.py
+++ b/test/oauth2_test.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime, timedelta
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch
@@ -693,6 +694,42 @@ This is not a JSON response
         self.assertEqual(mock_request.call_count, 2)
 
         await rest_client.close()
+
+    async def test_concurrent_requests_only_fetch_token_once(self):
+        """
+        Multiple concurrent requests while the token is invalid should result in
+        only one token fetch — subsequent coroutines wait on the lock and reuse
+        the token obtained by the first.
+        """
+        obtain_calls = []
+
+        credentials = Credentials(
+            method="client_credentials",
+            configuration=CredentialConfiguration(
+                client_id="myclientid",
+                client_secret="mysecret",
+                api_issuer="issuer.fga.example",
+                api_audience="myaudience",
+            ),
+        )
+        oauth_client = OAuth2Client(credentials)
+
+        async def mock_obtain_token(client):
+            obtain_calls.append(1)
+            await asyncio.sleep(0)  # yield so other coroutines reach the lock
+            oauth_client._access_token = "concurrent-token"
+            oauth_client._access_expiry_time = datetime.now() + timedelta(seconds=3600)
+            oauth_client._access_token_expiry_buffer = 300
+
+        with patch.object(oauth_client, "_obtain_token", side_effect=mock_obtain_token):
+            results = await asyncio.gather(
+                *[oauth_client.get_authentication_header(None) for _ in range(5)]
+            )
+
+        self.assertEqual(len(obtain_calls), 1)
+        self.assertTrue(
+            all(r == {"Authorization": "Bearer concurrent-token"} for r in results)
+        )
 
     @patch.object(rest.RESTClientObject, "request")
     async def test_get_authentication_with_scopes_no_audience(self, mock_request):

--- a/test/sync/oauth2_test.py
+++ b/test/sync/oauth2_test.py
@@ -511,6 +511,7 @@ This is not a JSON response
             for t in threads:
                 t.join()
 
+        self.assertEqual(len(results), 5)
         self.assertEqual(len(obtain_calls), 1)
         self.assertTrue(
             all(r == {"Authorization": "Bearer concurrent-token"} for r in results)

--- a/test/sync/oauth2_test.py
+++ b/test/sync/oauth2_test.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import urllib3
 
 from openfga_sdk.configuration import Configuration
-from openfga_sdk.constants import USER_AGENT
+from openfga_sdk.constants import TOKEN_EXPIRY_THRESHOLD_BUFFER_IN_SEC, USER_AGENT
 from openfga_sdk.credentials import CredentialConfiguration, Credentials
 from openfga_sdk.exceptions import AuthenticationError
 from openfga_sdk.sync import rest
@@ -34,7 +34,7 @@ class TestOAuth2Client(IsolatedAsyncioTestCase):
         """
         client = OAuth2Client(None)
         client._access_token = "XYZ123"
-        client._access_expiry_time = datetime.now() + timedelta(seconds=60)
+        client._access_expiry_time = datetime.now() + timedelta(seconds=3600)
         auth_header = client.get_authentication_header(None)
         self.assertEqual(auth_header, {"Authorization": "Bearer XYZ123"})
 
@@ -425,6 +425,49 @@ This is not a JSON response
                 "grant_type": "client_credentials",
             },
         )
+        rest_client.close()
+
+    @patch.object(rest.RESTClientObject, "request")
+    @patch("openfga_sdk.sync.oauth2.random")
+    def test_get_authentication_refreshes_near_expiry_token(
+        self, mock_random, mock_request
+    ):
+        """
+        Token close to expiry (within buffer window) should trigger a proactive refresh
+        """
+        mock_random.random.return_value = 0
+        short_lived_secs = max(1, TOKEN_EXPIRY_THRESHOLD_BUFFER_IN_SEC - 1)
+
+        mock_request.side_effect = [
+            mock_response(
+                f'{{"expires_in": {short_lived_secs}, "access_token": "short-lived-token"}}',
+                200,
+            ),
+            mock_response(
+                '{"expires_in": 3600, "access_token": "refreshed-token"}',
+                200,
+            ),
+        ]
+
+        credentials = Credentials(
+            method="client_credentials",
+            configuration=CredentialConfiguration(
+                client_id="myclientid",
+                client_secret="mysecret",
+                api_issuer="issuer.fga.example",
+                api_audience="myaudience",
+            ),
+        )
+        rest_client = rest.RESTClientObject(Configuration())
+        client = OAuth2Client(credentials)
+
+        header1 = client.get_authentication_header(rest_client)
+        header2 = client.get_authentication_header(rest_client)
+
+        self.assertEqual(header1, {"Authorization": "Bearer short-lived-token"})
+        self.assertEqual(header2, {"Authorization": "Bearer refreshed-token"})
+        self.assertEqual(mock_request.call_count, 2)
+
         rest_client.close()
 
     @patch.object(rest.RESTClientObject, "request")

--- a/test/sync/oauth2_test.py
+++ b/test/sync/oauth2_test.py
@@ -1,5 +1,6 @@
 import threading
 import time
+
 from datetime import datetime, timedelta
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch

--- a/test/sync/oauth2_test.py
+++ b/test/sync/oauth2_test.py
@@ -1,3 +1,5 @@
+import threading
+import time
 from datetime import datetime, timedelta
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch
@@ -470,6 +472,49 @@ This is not a JSON response
 
         rest_client.close()
 
+    def test_concurrent_requests_only_fetch_token_once(self):
+        """
+        Multiple concurrent threads while the token is invalid should result in
+        only one token fetch — subsequent threads wait on the lock and reuse
+        the token obtained by the first.
+        """
+        obtain_calls = []
+
+        credentials = Credentials(
+            method="client_credentials",
+            configuration=CredentialConfiguration(
+                client_id="myclientid",
+                client_secret="mysecret",
+                api_issuer="issuer.fga.example",
+                api_audience="myaudience",
+            ),
+        )
+        oauth_client = OAuth2Client(credentials)
+
+        def mock_obtain_token(client):
+            obtain_calls.append(1)
+            time.sleep(0.05)  # hold the lock briefly so other threads queue up
+            oauth_client._access_token = "concurrent-token"
+            oauth_client._access_expiry_time = datetime.now() + timedelta(seconds=3600)
+            oauth_client._access_token_expiry_buffer = 300
+
+        results = []
+
+        def call():
+            results.append(oauth_client.get_authentication_header(None))
+
+        with patch.object(oauth_client, "_obtain_token", side_effect=mock_obtain_token):
+            threads = [threading.Thread(target=call) for _ in range(5)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        self.assertEqual(len(obtain_calls), 1)
+        self.assertTrue(
+            all(r == {"Authorization": "Bearer concurrent-token"} for r in results)
+        )
+
     @patch.object(rest.RESTClientObject, "request")
     def test_get_authentication_with_scopes_no_audience(self, mock_request):
         """
@@ -520,4 +565,3 @@ This is not a JSON response
             },
         )
         rest_client.close()
-

--- a/test/sync/oauth2_test.py
+++ b/test/sync/oauth2_test.py
@@ -11,8 +11,9 @@ from openfga_sdk.configuration import Configuration
 from openfga_sdk.constants import TOKEN_EXPIRY_THRESHOLD_BUFFER_IN_SEC, USER_AGENT
 from openfga_sdk.credentials import CredentialConfiguration, Credentials
 from openfga_sdk.exceptions import AuthenticationError
+from openfga_sdk.oauth2_common import _TokenState
 from openfga_sdk.sync import rest
-from openfga_sdk.sync.oauth2 import OAuth2Client, _TokenState
+from openfga_sdk.sync.oauth2 import OAuth2Client
 
 
 # Helper function to construct mock response

--- a/test/sync/oauth2_test.py
+++ b/test/sync/oauth2_test.py
@@ -12,7 +12,7 @@ from openfga_sdk.constants import TOKEN_EXPIRY_THRESHOLD_BUFFER_IN_SEC, USER_AGE
 from openfga_sdk.credentials import CredentialConfiguration, Credentials
 from openfga_sdk.exceptions import AuthenticationError
 from openfga_sdk.sync import rest
-from openfga_sdk.sync.oauth2 import OAuth2Client
+from openfga_sdk.sync.oauth2 import OAuth2Client, _TokenState
 
 
 # Helper function to construct mock response
@@ -36,8 +36,11 @@ class TestOAuth2Client(IsolatedAsyncioTestCase):
         Test getting authentication header when method is client credentials
         """
         client = OAuth2Client(None)
-        client._access_token = "XYZ123"
-        client._access_expiry_time = datetime.now() + timedelta(seconds=3600)
+        client._token_state = _TokenState(
+            access_token="XYZ123",
+            expiry_time=datetime.now() + timedelta(seconds=3600),
+            expiry_buffer=0,
+        )
         auth_header = client.get_authentication_header(None)
         self.assertEqual(auth_header, {"Authorization": "Bearer XYZ123"})
 
@@ -68,9 +71,9 @@ class TestOAuth2Client(IsolatedAsyncioTestCase):
         client = OAuth2Client(credentials)
         auth_header = client.get_authentication_header(rest_client)
         self.assertEqual(auth_header, {"Authorization": "Bearer AABBCCDD"})
-        self.assertEqual(client._access_token, "AABBCCDD")
+        self.assertEqual(client._token_state.access_token, "AABBCCDD")
         self.assertGreaterEqual(
-            client._access_expiry_time, current_time + timedelta(seconds=120)
+            client._token_state.expiry_time, current_time + timedelta(seconds=120)
         )
         expected_header = urllib3.response.HTTPHeaderDict(
             {
@@ -126,9 +129,9 @@ class TestOAuth2Client(IsolatedAsyncioTestCase):
         client = OAuth2Client(credentials)
         auth_header = client.get_authentication_header(rest_client)
         self.assertEqual(auth_header, {"Authorization": "Bearer AABBCCDD"})
-        self.assertEqual(client._access_token, "AABBCCDD")
+        self.assertEqual(client._token_state.access_token, "AABBCCDD")
         self.assertGreaterEqual(
-            client._access_expiry_time, current_time + timedelta(seconds=120)
+            client._token_state.expiry_time, current_time + timedelta(seconds=120)
         )
         expected_header = urllib3.response.HTTPHeaderDict(
             {
@@ -185,9 +188,9 @@ class TestOAuth2Client(IsolatedAsyncioTestCase):
         client = OAuth2Client(credentials)
         auth_header = client.get_authentication_header(rest_client)
         self.assertEqual(auth_header, {"Authorization": "Bearer AABBCCDD"})
-        self.assertEqual(client._access_token, "AABBCCDD")
+        self.assertEqual(client._token_state.access_token, "AABBCCDD")
         self.assertGreaterEqual(
-            client._access_expiry_time, current_time + timedelta(seconds=120)
+            client._token_state.expiry_time, current_time + timedelta(seconds=120)
         )
         expected_header = urllib3.response.HTTPHeaderDict(
             {
@@ -268,8 +271,11 @@ class TestOAuth2Client(IsolatedAsyncioTestCase):
         rest_client = rest.RESTClientObject(Configuration())
         client = OAuth2Client(credentials)
 
-        client._access_token = "XYZ123"
-        client._access_expiry_time = datetime.now() - timedelta(seconds=240)
+        client._token_state = _TokenState(
+            access_token="XYZ123",
+            expiry_time=datetime.now() - timedelta(seconds=240),
+            expiry_buffer=0,
+        )
 
         with self.assertRaises(AuthenticationError):
             client.get_authentication_header(rest_client)
@@ -495,9 +501,11 @@ This is not a JSON response
         def mock_obtain_token(client):
             obtain_calls.append(1)
             time.sleep(0.05)  # hold the lock briefly so other threads queue up
-            oauth_client._access_token = "concurrent-token"
-            oauth_client._access_expiry_time = datetime.now() + timedelta(seconds=3600)
-            oauth_client._access_token_expiry_buffer = 300
+            oauth_client._token_state = _TokenState(
+                access_token="concurrent-token",
+                expiry_time=datetime.now() + timedelta(seconds=3600),
+                expiry_buffer=300,
+            )
 
         results = []
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

Mirrors the same bug fix as in the JS sdk https://github.com/openfga/js-sdk/pull/331
Tokens were being used until the exact moment of expiry. Added an expiry buffer (with jitter) so tokens are refreshed before they expire, preventing in-flight requests from hitting the server with an expired token.

Under burst concurrency, multiple coroutines/threads could simultaneously see the token as invalid and all fetch a new one. Added asyncio.Lock (async) and threading.Lock (sync) with double-checked locking so only one refresh happens and the rest reuse the result.

#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * OAuth2 tokens are now refreshed with improved expiry detection using configurable buffer thresholds
  * Concurrent authentication requests are now properly synchronized to prevent duplicate token refreshes

* **Tests**
  * Added comprehensive test coverage for token refresh behavior near expiration and concurrent request handling scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->