### PR TITLE
feat: add support for Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         urllib3-version: ["1.26.19", "2.2.2"]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ classifiers=[
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 keywords=[
     "openfga",


### PR DESCRIPTION
 ## Summary

  Brings the SDK's tested and advertised Python versions in line with the [OpenFGA Language & Framework Version Support Policy](https://github.com/orgs/openfga/discussions/531).

  The policy requires supporting every Python version currently in the **bug-fix** or **security-fix** phase per the [Python Developer's Guide](https://devguide.python.org/versions/). As of this change the
  supported set is **3.10, 3.11, 3.12, 3.13, 3.14**. The repo previously only covered 3.10–3.12, leaving the two newest actively-developed releases (3.13 and 3.14, both in the bug-fix phase) untested and
  unadvertised.

  ## Changes

  - **`.github/workflows/main.yaml`** — add `3.13` and `3.14` to the `test` job's `python-version` matrix.
  - **`pyproject.toml`** — add the `Programming Language :: Python :: 3.13` and `:: 3.14` trove classifiers.

  ## Policy alignment

  | Python | Phase (Jun 2026) | Before | After |
  |--------|------------------|--------|-------|
  | 3.10 | security | ✅ | ✅ |
  | 3.11 | security | ✅ | ✅ |
  | 3.12 | security | ✅ | ✅ |
  | 3.13 | bugfix | ❌ | ✅ |
  | 3.14 | bugfix | ❌ | ✅ |
  | 3.9 | EOL (Oct 2025) | — | — (correctly excluded) |

  ## Intentionally unchanged

  - `requires-python = ">=3.10"` — floor stays at the oldest supported version; 3.9 is EOL.
  - `target-version = "py310"` (ruff) and `python_version = "3.10"` (mypy) — these target the **minimum** supported version for lint/type-check, which is correct.
  - The single-version steps (ruff/codecov gate, publish) remain pinned to `3.10`.
  - `.snyk` interpreter pin (`3.10.6`) — scanner resolves deps against the floor version; left as-is.

  ## Notes

  - The `test` matrix also has a `urllib3-version` axis (`1.26.19`, `2.2.2`), so this adds 4 new CI cells (2 Python × 2 urllib3).
  - `aiohttp` is unpinned (`>=3.9.3`); the lockfile already resolves aiohttp 3.14.x, which ships 3.13/3.14 wheels.

  ## Test plan

  - [ ] CI matrix passes on the new `3.13` and `3.14` cells (both urllib3 variants)
  - [ ] `urllib3==1.26.19` (pinned legacy line) installs and imports cleanly on 3.13 and 3.14
  - [ ] Package builds and classifiers render correctly on PyPI metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded CI test coverage to run against newer Python versions, including 3.13 and 3.14.
  * Updated supported Python version metadata to reflect the added version compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->